### PR TITLE
Fix playground by correctly externalizing vue

### DIFF
--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -100,31 +100,6 @@ describe('Auth0Plugin', () => {
     );
   });
 
-  it('should create a proxy on installation by passing global Vue', async () => {
-    const plugin = createAuth0(
-      {
-        domain: 'domain 123',
-        client_id: 'client id 123',
-        foo: 'bar'
-      },
-      {
-        ref: () => ({ value: null })
-      }
-    );
-
-    plugin.install(appMock);
-
-    expect(appMock.config.globalProperties.$auth0).toBeTruthy();
-    expect(appMock.provide).toHaveBeenCalled();
-    expect(Auth0Client).toHaveBeenCalledWith(
-      expect.objectContaining({
-        domain: 'domain 123',
-        client_id: 'client id 123',
-        foo: 'bar'
-      })
-    );
-  });
-
   it('should call checkSession on installation', async () => {
     const plugin = createAuth0({
       domain: '',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -73,7 +73,10 @@ let bundles = [
       footer,
       format: 'umd',
       sourcemap: true,
-      exports: 'default'
+      exports: 'default',
+      globals: {
+        vue: 'Vue'
+      }
     },
     plugins: [
       ...getPlugins(false),
@@ -89,7 +92,8 @@ let bundles = [
     ],
     watch: {
       clearScreen: false
-    }
+    },
+    external: ['vue']
   }
 ];
 

--- a/src/client.proxy.ts
+++ b/src/client.proxy.ts
@@ -21,13 +21,13 @@ export class Auth0ClientProxy {
   public user: Ref<User | undefined>;
   public idTokenClaims: Ref<IdToken | undefined>;
 
-  constructor(options: Auth0ClientOptions, vue?: any) {
+  constructor(options: Auth0ClientOptions) {
     this.client = new Auth0Client(options);
 
-    this.isLoading = vue ? vue.ref(true) : ref(true);
-    this.isAuthenticated = vue ? vue.ref(false) : ref(false);
-    this.user = vue ? vue.ref({}) : ref({});
-    this.idTokenClaims = vue ? vue.ref() : ref();
+    this.isLoading = ref(true);
+    this.isAuthenticated = ref(false);
+    this.user = ref({});
+    this.idTokenClaims = ref();
   }
 
   async loginWithRedirect(options?: RedirectLoginOptions) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,6 @@ export * from './global';
  * @param options The plugin options
  * @returns An instance of Auth0Plugin
  */
-export default function createAuth0(options: Auth0PluginOptions, vue?: any) {
-  return new Auth0Plugin(options, vue);
+export default function createAuth0(options: Auth0PluginOptions) {
+  return new Auth0Plugin(options);
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -10,19 +10,16 @@ export interface Auth0PluginOptions extends Auth0ClientOptions {
 }
 
 export class Auth0Plugin {
-  constructor(private options: Auth0PluginOptions, private vue?: any) {}
+  constructor(private options: Auth0PluginOptions) {}
 
   install(app: App) {
-    const proxy = new Auth0ClientProxy(
-      {
-        ...this.options,
-        auth0Client: {
-          name: 'auth0-vue',
-          version: version
-        }
-      },
-      this.vue
-    );
+    const proxy = new Auth0ClientProxy({
+      ...this.options,
+      auth0Client: {
+        name: 'auth0-vue',
+        version: version
+      }
+    });
 
     this.__checkSession(proxy);
 

--- a/static/index.html
+++ b/static/index.html
@@ -164,8 +164,8 @@
       </div>
     </div>
 
-    <script src="/auth0-vue.development.js"></script>
     <script src="https://unpkg.com/vue@next"></script>
+    <script src="/auth0-vue.development.js"></script>
     <script type="text/javascript">
       const defaultDomain = 'http://127.0.0.1:3000';
       const defaultClientId = 'testing';
@@ -308,7 +308,7 @@
           client_id: res?.client_id || defaultClientId,
           audience: res?.audience || defaultAudience,
           useFormData: res?.useFormData || true
-        }, Vue)
+        })
       );
 
       app.mount('#app');


### PR DESCRIPTION
There is an issue where the playground does not pick up changes to the reactive properties.
This appears to be because of the fact that we bundle Vue with our bundle, yet bring it in another time in our playground, meaning they don't share the same Vue source files, which turns out to be problematic.

Removing Vue from our bundle solves this, meaning we can also drop passing Vue to createAuth0.