### PR TITLE
Fix error when booting oidc-provider

### DIFF
--- a/scripts/oidc-provider.js
+++ b/scripts/oidc-provider.js
@@ -96,7 +96,7 @@ export function createApp(opts) {
   provider.use(async (ctx, next) => {
     await next();
 
-    if (ctx.oidc.route === 'end_session_success') {
+    if (ctx.oidc?.route === 'end_session_success') {
       ctx.redirect('http://127.0.0.1:3000');
     }
   });


### PR DESCRIPTION
When running `npm start`, the console shows an error `Can not access property route of undefined`.