### PR TITLE
Do not return false from guard when redirecting

### DIFF
--- a/src/guard.ts
+++ b/src/guard.ts
@@ -23,8 +23,6 @@ export function createAuthGuard(app: App) {
       }
 
       await auth0.loginWithRedirect({ appState: { target: to.fullPath } });
-
-      return false;
     };
 
     if (!auth0.isLoading.value) {


### PR DESCRIPTION
Returning false cancels the request to `/authorize`, which introduced an issue when the user would go straight to a protected route instead of going to the `/` and using the navigation menu.

In that case, the redirect to Auth0 was cancelled because of the `return false`. We should not block navigation in that scenario, as we know we are redirecting away from the application anyway.