### PR TITLE
Update codecov badge to point to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Auth0 SDK for Vue Applications using [Authorization Code Grant Flow with PKCE](h
 
 ![Stage: Beta Release](https://img.shields.io/badge/stage-beta-orange)
 [![CircleCI](https://img.shields.io/circleci/build/github/auth0/auth0-vue)](https://circleci.com/gh/auth0/auth0-vue)
-[![codecov](https://codecov.io/gh/auth0/auth0-vue/branch/master/graph/badge.svg?token=cXvbJYzadm)](https://codecov.io/gh/auth0/auth0-vue)
+[![codecov](https://codecov.io/gh/auth0/auth0-vue/branch/main/graph/badge.svg)](https://codecov.io/gh/auth0/auth0-vue)
 [![License](https://img.shields.io/:license-mit-blue.svg?style=flat)](https://opensource.org/licenses/MIT)
 
 ## Table of Contents


### PR DESCRIPTION
The badge was incorrectly pointing to **master**, it should be **main**.