### PR TITLE
Update Circle CI config to incluse auth0/ship

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  ship: auth0/ship@0.3.1
 parameters:
   docker_image:
     type: string
@@ -47,3 +49,14 @@ workflows:
             - build
           context:
             - browserstack-env
+      - ship/node-publish:
+          publish-command: npm run build && npm publish
+          context:
+            - publish-npm
+            - publish-gh
+          filters:
+            branches:
+              only:
+                - main
+          requires:
+            - browserstack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ workflows:
           context:
             - browserstack-env
       - ship/node-publish:
-          publish-command: npm run build && npm publish
+          publish-command: npm run build && npm publish --tag beta
           context:
             - publish-npm
             - publish-gh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ workflows:
           context:
             - browserstack-env
       - ship/node-publish:
-          publish-command: npm run build && npm publish --tag beta
+          publish-command: npm publish --tag beta
           context:
             - publish-npm
             - publish-gh


### PR DESCRIPTION
Adds integration with the `auth0/ship` orb to automatically publish to NPM and GitHub.