### PR TITLE
Avoid using publish-gh with node-publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,6 @@ workflows:
           publish-command: npm publish --tag beta
           context:
             - publish-npm
-            - publish-gh
           filters:
             branches:
               only:


### PR DESCRIPTION
Test github releasing with a different token.

PR will be reverted after merging.