### PR TITLE
Refactor history.replaceState usage

### DIFF
--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -201,7 +201,7 @@ describe('Auth0Plugin', () => {
     expect(handleRedirectCallbackMock).not.toHaveBeenCalled();
 
     return flushPromises().then(() => {
-      expect(replaceStateMock).toHaveBeenCalled();
+      expect(replaceStateMock).not.toHaveBeenCalled();
     });
   });
 
@@ -225,7 +225,7 @@ describe('Auth0Plugin', () => {
     expect(handleRedirectCallbackMock).not.toHaveBeenCalled();
 
     return flushPromises().then(() => {
-      expect(replaceStateMock).toHaveBeenCalled();
+      expect(replaceStateMock).not.toHaveBeenCalled();
     });
   });
 
@@ -271,11 +271,20 @@ describe('Auth0Plugin', () => {
       }
     });
 
+    const urlParams = new URLSearchParams(window.location.search);
+
+    urlParams.set('code', '123');
+    urlParams.set('state', 'xyz');
+
+    window.location.search = urlParams as any;
+
     plugin.install(appMock);
 
-    await appMock.config.globalProperties.$auth0.handleRedirectCallback();
+    expect.assertions(1);
 
-    expect(routerPushMock).toHaveBeenCalledWith('abc');
+    return flushPromises().then(() => {
+      expect(routerPushMock).toHaveBeenCalledWith('abc');
+    });
   });
 
   it('should call the router, if provided, with the default path when no target provided', async () => {
@@ -293,11 +302,18 @@ describe('Auth0Plugin', () => {
       appState: {}
     });
 
+    const urlParams = new URLSearchParams(window.location.search);
+
+    urlParams.set('code', '123');
+    urlParams.set('state', 'xyz');
+
+    window.location.search = urlParams as any;
+
     plugin.install(appMock);
 
-    await appMock.config.globalProperties.$auth0.handleRedirectCallback();
-
-    expect(routerPushMock).toHaveBeenCalledWith('/');
+    return flushPromises().then(() => {
+      expect(routerPushMock).toHaveBeenCalledWith('/');
+    });
   });
 
   it('should proxy loginWithRedirect', async () => {

--- a/playground/router.ts
+++ b/playground/router.ts
@@ -1,8 +1,4 @@
-import { App } from 'vue';
-import {
-  createRouter as createVueRouter,
-  createWebHashHistory
-} from 'vue-router';
+import { createRouter as createVueRouter, createWebHistory } from 'vue-router';
 import { authGuard } from '../src/guard';
 // Fix for https://github.com/ezolenko/rollup-plugin-typescript2/issues/129#issuecomment-454558185
 // @ts-ignore
@@ -32,6 +28,6 @@ export function createRouter({ client_id, domain, audience }: any) {
         beforeEnter: authGuard
       }
     ],
-    history: createWebHashHistory()
+    history: createWebHistory()
   });
 }

--- a/src/client.proxy.ts
+++ b/src/client.proxy.ts
@@ -21,8 +21,7 @@ import { Auth0VueClient, AppState } from './interfaces';
  * @ignore
  */
 export const createAuth0ClientProxy = (
-  options: Auth0ClientOptions,
-  globalProperties?: Record<string, any>
+  options: Auth0ClientOptions
 ): Auth0VueClient => {
   const client = new SpaAuth0Client(options);
   const isLoading: Ref<boolean> = ref(true);
@@ -108,20 +107,7 @@ export const createAuth0ClientProxy = (
     async handleRedirectCallback(
       url?: string
     ): Promise<RedirectLoginResult<AppState>> {
-      const result = await __proxy(() =>
-        client.handleRedirectCallback<AppState>(url)
-      );
-
-      const appState = result?.appState;
-      const target = appState?.target ?? '/';
-
-      const router = globalProperties.$router as Router;
-
-      if (router && router.push) {
-        router.push(target);
-      }
-
-      return result;
+      return __proxy(() => client.handleRedirectCallback<AppState>(url));
     },
 
     async buildAuthorizeUrl(options?: RedirectLoginOptions) {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -54,7 +54,5 @@ export class Auth0Plugin {
     } else {
       await proxy.checkSession();
     }
-
-    window.history.replaceState({}, '', '/');
   }
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -50,7 +50,12 @@ export class Auth0Plugin {
       search.includes('state=') &&
       !this.pluginOptions?.skipRedirectCallback
     ) {
-      await proxy.handleRedirectCallback();
+      const res = await proxy.handleRedirectCallback();
+      window.history.replaceState(
+        {},
+        document.title,
+        res?.appState?.target || window.location.pathname
+      );
     } else {
       await proxy.checkSession();
     }


### PR DESCRIPTION
<!-- By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. -->

### Changes

Removed the `window.location.replaceState()` from the plugin initialization when checking the session.
The browser URL is no longer replaced with `/` when refreshing the browser.

### References

https://github.com/auth0/auth0-vue/issues/88

### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
