### PR TITLE
FIX logout options not required

### DIFF
--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -357,6 +357,18 @@ describe('Auth0Plugin', () => {
     expect(logoutMock).toHaveBeenCalledWith(logoutOptions);
   });
 
+  it('should proxy logout without options', async () => {
+    const plugin = createAuth0({
+      domain: '',
+      client_id: ''
+    });
+
+    plugin.install(appMock);
+
+    await appMock.config.globalProperties.$auth0.logout();
+    expect(logoutMock).toHaveBeenCalledWith(undefined);
+  });
+
   it('should proxy getAccessTokenSilently', async () => {
     const plugin = createAuth0({
       domain: '',

--- a/src/client.proxy.ts
+++ b/src/client.proxy.ts
@@ -89,7 +89,7 @@ export const createAuth0ClientProxy = (
     },
 
     async logout(options?: LogoutOptions) {
-      return __proxy(() => client.logout(options), options.localOnly);
+      return __proxy(() => client.logout(options), options?.localOnly);
     },
 
     getAccessTokenSilently,


### PR DESCRIPTION
<!-- By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. -->

### Changes

- made arg passed from client proxy to client optional
- fixes `logout()` thrown an exception when called with no args.

### References

Fixes https://github.com/auth0/auth0-vue/issues/91

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
