### PR TITLE
Bind all methods of Auth0VueClient to this

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -175,7 +175,7 @@ export class Auth0Plugin implements Auth0VueClient {
   private async __proxy<T>(cb: () => T, refreshState = true) {
     let result;
     try {
-      result = await cb.call(this);
+      result = await cb();
       this._error.value = null;
     } catch (e) {
       this._error.value = e;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -22,6 +22,7 @@ import {
   RedirectLoginResult,
   User
 } from '@auth0/auth0-spa-js';
+import { bindPluginMethods } from './utils';
 
 /**
  * @ignore
@@ -49,22 +50,9 @@ export class Auth0Plugin implements Auth0VueClient {
     private clientOptions: Auth0VueClientOptions,
     private pluginOptions?: Auth0PluginOptions
   ) {
-    const plugin = this;
-
     // Vue Plugins can have issues when passing around the instance to `provide`
     // Therefor we need to bind all methods correctly to `this`.
-    this.loginWithRedirect = this.loginWithRedirect.bind(plugin);
-    this.loginWithPopup = this.loginWithPopup.bind(plugin);
-    this.logout = this.logout.bind(plugin);
-    this.getAccessTokenSilently = this.getAccessTokenSilently.bind(plugin);
-    this.getAccessTokenWithPopup = this.getAccessTokenWithPopup.bind(plugin);
-    this.checkSession = this.checkSession.bind(plugin);
-    this.handleRedirectCallback = this.handleRedirectCallback.bind(plugin);
-    this.buildAuthorizeUrl = this.buildAuthorizeUrl.bind(plugin);
-    this.buildLogoutUrl = this.buildLogoutUrl.bind(plugin);
-    this.__checkSession = this.__checkSession.bind(plugin);
-    this.__refreshState = this.__refreshState.bind(plugin);
-    this.__proxy = this.__proxy.bind(plugin);
+    bindPluginMethods(this, ['constructor']);
   }
 
   install(app: App) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,3 +24,13 @@ export function watchEffectOnce<T>(watcher: () => T, fn: Function) {
     }
   });
 }
+
+/**
+ * @ignore
+ * Helper function to bind methods to itself, useful when using Vue's `provide` / `inject` API's.
+ */
+export function bindPluginMethods(plugin: any, exclude: string[]) {
+  Object.getOwnPropertyNames(Object.getPrototypeOf(plugin))
+    .filter(method => !exclude.includes(method))
+    .forEach(method => (plugin[method] = plugin[method].bind(plugin)));
+}


### PR DESCRIPTION
There seems to be an issue when setting `this` as the value when calling Vue's `provide`. To solve it, we should bind all methods using `this`.
[Vuex appeared to have solved it in the same way](https://github.com/vuejs/vuex/blob/main/src/store.js#L50).