### PR TITLE
Export spa-js types, default docs to show inherited and external

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -1,3 +1,21 @@
 export { Auth0Plugin } from './plugin';
 export * from './interfaces';
 export * from './guard';
+
+export {
+    AuthorizationParams,
+    PopupLoginOptions,
+    PopupConfigOptions,
+    GetTokenWithPopupOptions,
+    LogoutOptions,
+    LogoutUrlOptions,
+    CacheLocation,
+    GetTokenSilentlyOptions,
+    IdToken,
+    User,
+    ICache,
+    InMemoryCache,
+    LocalStorageCache,
+    Cacheable,
+    RedirectLoginOptions,
+  } from '@auth0/auth0-spa-js';

--- a/typedoc.js
+++ b/typedoc.js
@@ -12,5 +12,10 @@ module.exports = {
   ],
   excludeExternals: false,
   excludePrivate: true,
-  hideGenerator: true
+  hideGenerator: true,
+  visibilityFilters: {
+    protected: false,
+    inherited: true,
+    external: true,
+  }
 };


### PR DESCRIPTION
### Changes

Exports some of the used types from spa-js so that the auth0-vue doc now include them making it easier to determine supported properties.

Also sets the [visibilityFilters](https://typedoc.org/guides/options/#visibilityfilters) property in the typedoc config so that the API reference site now defaults to showing external and inherited properties by default rather than only when asked for, you might need to clear localstorage for the site to see the first time experience of these being toggled off.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
