### PR TITLE
Update spa-js and omit onRedirect from exported types

### DIFF
--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -408,7 +408,7 @@ describe('Auth0Plugin', () => {
     });
 
     const logoutOptions = {
-      async onRedirect() {}
+      openUrl: false as const
     };
 
     plugin.install(appMock);
@@ -679,7 +679,7 @@ describe('Auth0Plugin', () => {
 
     try {
       await appMock.config.globalProperties.$auth0.logout({
-        async onRedirect() {}
+        async openUrl() {}
       });
     } catch (e) {}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@auth0/auth0-spa-js": "^2.0.0",
+        "@auth0/auth0-spa-js": "^2.0.1",
         "vue": "^3.2.41"
       },
       "devDependencies": {
@@ -77,9 +77,9 @@
       }
     },
     "node_modules/@auth0/auth0-spa-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.0.0.tgz",
-      "integrity": "sha512-qHArgvA+ltI37g1vo3q7XtWxhMNAyL0LrnwCKCHQ1uzMWnxhdyxi2w9/BXfp1c+2L1Zc+DDh3XhpbYVXNhvadg=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.0.1.tgz",
+      "integrity": "sha512-ThNsY+T6CTRvpjc4L1G/DBG3AgWsleCbXUJ9rTySCDPmYzASjJlo0H3dilASgrBI6NsvUtQJUF5nQy+AbiFilQ=="
     },
     "node_modules/@auth0/component-cdn-uploader": {
       "version": "2.2.2",
@@ -14715,9 +14715,9 @@
       }
     },
     "@auth0/auth0-spa-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.0.0.tgz",
-      "integrity": "sha512-qHArgvA+ltI37g1vo3q7XtWxhMNAyL0LrnwCKCHQ1uzMWnxhdyxi2w9/BXfp1c+2L1Zc+DDh3XhpbYVXNhvadg=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.0.1.tgz",
+      "integrity": "sha512-ThNsY+T6CTRvpjc4L1G/DBG3AgWsleCbXUJ9rTySCDPmYzASjJlo0H3dilASgrBI6NsvUtQJUF5nQy+AbiFilQ=="
     },
     "@auth0/component-cdn-uploader": {
       "version": "git+ssh://git@github.com/auth0/component-cdn-uploader.git#c86a1f043b9f30b3a3407b19b2e6cd9f1ccdc21b",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "wait-on": "^6.0.0"
   },
   "dependencies": {
-    "@auth0/auth0-spa-js": "^2.0.0",
+    "@auth0/auth0-spa-js": "^2.0.1",
     "vue": "^3.2.41"
   },
   "peerDependencies": {

--- a/playground/components/Home.vue
+++ b/playground/components/Home.vue
@@ -260,7 +260,7 @@ export default {
 
       logoutLocal: function () {
         auth0.logout({
-          onRedirect: async () => {},
+          openUrl: false,
           logoutParams: {
             returnTo: window.location.origin,
           }

--- a/src/global.ts
+++ b/src/global.ts
@@ -3,19 +3,17 @@ export * from './interfaces';
 export * from './guard';
 
 export {
-    AuthorizationParams,
-    PopupLoginOptions,
-    PopupConfigOptions,
-    GetTokenWithPopupOptions,
-    LogoutOptions,
-    LogoutUrlOptions,
-    CacheLocation,
-    GetTokenSilentlyOptions,
-    IdToken,
-    User,
-    ICache,
-    InMemoryCache,
-    LocalStorageCache,
-    Cacheable,
-    RedirectLoginOptions,
-  } from '@auth0/auth0-spa-js';
+  AuthorizationParams,
+  PopupLoginOptions,
+  PopupConfigOptions,
+  GetTokenWithPopupOptions,
+  LogoutUrlOptions,
+  CacheLocation,
+  GetTokenSilentlyOptions,
+  IdToken,
+  User,
+  ICache,
+  InMemoryCache,
+  LocalStorageCache,
+  Cacheable,
+} from '@auth0/auth0-spa-js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import { inject } from 'vue';
-import { Router } from 'vue-router';
 import './global';
 import {
   Auth0VueClient,

--- a/src/interfaces/auth0-vue-client-options.ts
+++ b/src/interfaces/auth0-vue-client-options.ts
@@ -1,6 +1,14 @@
-import type { Auth0ClientOptions } from '@auth0/auth0-spa-js';
+import type {
+  Auth0ClientOptions,
+  LogoutOptions as SPALogoutOptions,
+  RedirectLoginOptions as SPARedirectLoginOptions
+} from '@auth0/auth0-spa-js';
 
 /**
  * Configuration for the Auth0 Vue Client
  */
 export interface Auth0VueClientOptions extends Auth0ClientOptions {}
+
+export interface LogoutOptions extends Omit<SPALogoutOptions, 'onRedirect'> {}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface RedirectLoginOptions<TAppState = any> extends Omit<SPARedirectLoginOptions<TAppState>, 'onRedirect'> {}

--- a/src/interfaces/auth0-vue-client-options.ts
+++ b/src/interfaces/auth0-vue-client-options.ts
@@ -3,6 +3,7 @@ import type {
   LogoutOptions as SPALogoutOptions,
   RedirectLoginOptions as SPARedirectLoginOptions
 } from '@auth0/auth0-spa-js';
+import { AppState } from './app-state';
 
 /**
  * Configuration for the Auth0 Vue Client
@@ -10,5 +11,4 @@ import type {
 export interface Auth0VueClientOptions extends Auth0ClientOptions {}
 
 export interface LogoutOptions extends Omit<SPALogoutOptions, 'onRedirect'> {}
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface RedirectLoginOptions<TAppState = any> extends Omit<SPARedirectLoginOptions<TAppState>, 'onRedirect'> {}
+export interface RedirectLoginOptions<TAppState = AppState> extends Omit<SPARedirectLoginOptions<TAppState>, 'onRedirect'> {}

--- a/src/interfaces/auth0-vue-client.ts
+++ b/src/interfaces/auth0-vue-client.ts
@@ -1,17 +1,16 @@
 import type {
   User,
   IdToken,
-  RedirectLoginOptions,
   PopupLoginOptions,
   PopupConfigOptions,
   RedirectLoginResult,
   GetTokenSilentlyOptions,
   GetTokenSilentlyVerboseResponse,
-  GetTokenWithPopupOptions,
-  LogoutOptions
+  GetTokenWithPopupOptions
 } from '@auth0/auth0-spa-js';
 import type { Ref } from 'vue';
 import type { AppState } from './app-state';
+import { LogoutOptions, RedirectLoginOptions } from './auth0-vue-client-options';
 
 export interface Auth0VueClient {
   /**

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -5,7 +5,9 @@ import type {
   AppState,
   Auth0PluginOptions,
   Auth0VueClient,
-  Auth0VueClientOptions
+  Auth0VueClientOptions,
+  LogoutOptions,
+  RedirectLoginOptions,
 } from './interfaces';
 import { AUTH0_INJECTION_KEY, AUTH0_TOKEN } from './token';
 import version from './version';
@@ -14,10 +16,8 @@ import type {
   GetTokenSilentlyVerboseResponse,
   GetTokenWithPopupOptions,
   IdToken,
-  LogoutOptions,
   PopupConfigOptions,
   PopupLoginOptions,
-  RedirectLoginOptions,
   RedirectLoginResult,
 } from '@auth0/auth0-spa-js';
 import {
@@ -87,7 +87,7 @@ export class Auth0Plugin implements Auth0VueClient {
   }
 
   async logout(options?: LogoutOptions) {
-    if (options?.onRedirect) {
+    if (options?.openUrl || options?.openUrl === false) {
       return this.__proxy(() => this._client.logout(options));
     }
 


### PR DESCRIPTION
### Changes

Updates spa-js to 2.0.1 so that we pull in the openUrl update, updates the types so that LogoutOptions and RedirectLoginOptions are now from auth0-react and omit the onRedirect property, and also corrects the check around openUrl in light of the changes we made

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
