### PR TITLE
Upgrade @auth0/auth0-spa-js to 1.22.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@auth0/auth0-spa-js": "^1.22.5",
+        "@auth0/auth0-spa-js": "^1.22.6",
         "vue": "^3.2.41"
       },
       "devDependencies": {
@@ -79,13 +79,13 @@
       }
     },
     "node_modules/@auth0/auth0-spa-js": {
-      "version": "1.22.5",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.22.5.tgz",
-      "integrity": "sha512-6gaQcd+Eb8ZBcdQkrrm9undM7dY/rPvVdQN8s7rxxrviUCs7OopEygsfSkHf67IP4HtlCiE8dSW5/AipRUOw/A==",
+      "version": "1.22.6",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.22.6.tgz",
+      "integrity": "sha512-iL3O0vWanfKFVgy1J2ZHDPlAUK6EVHWEHWS6mUXwHEuPiK39tjlQtyUKQIJI1F5YsZB75ijGgRWMTawSDXlwCA==",
       "dependencies": {
         "abortcontroller-polyfill": "^1.7.3",
         "browser-tabs-lock": "^1.2.15",
-        "core-js": "^3.25.1",
+        "core-js": "^3.25.4",
         "es-cookie": "~1.3.2",
         "fast-text-encoding": "^1.0.6",
         "promise-polyfill": "^8.2.3",
@@ -17876,13 +17876,13 @@
       }
     },
     "@auth0/auth0-spa-js": {
-      "version": "1.22.5",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.22.5.tgz",
-      "integrity": "sha512-6gaQcd+Eb8ZBcdQkrrm9undM7dY/rPvVdQN8s7rxxrviUCs7OopEygsfSkHf67IP4HtlCiE8dSW5/AipRUOw/A==",
+      "version": "1.22.6",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.22.6.tgz",
+      "integrity": "sha512-iL3O0vWanfKFVgy1J2ZHDPlAUK6EVHWEHWS6mUXwHEuPiK39tjlQtyUKQIJI1F5YsZB75ijGgRWMTawSDXlwCA==",
       "requires": {
         "abortcontroller-polyfill": "^1.7.3",
         "browser-tabs-lock": "^1.2.15",
-        "core-js": "^3.25.1",
+        "core-js": "^3.25.4",
         "es-cookie": "~1.3.2",
         "fast-text-encoding": "^1.0.6",
         "promise-polyfill": "^8.2.3",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "wait-on": "^6.0.0"
   },
   "dependencies": {
-    "@auth0/auth0-spa-js": "^1.22.5",
+    "@auth0/auth0-spa-js": "^1.22.6",
     "vue": "^3.2.41"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Changes

Updates `@auth0/auth0-spa-js` to `1.22.6`, this version is identical to `1.22.5` but includes an update to the development dependency `jsonwebtoken`.

Even though `1.22.5` was not vulnerable for the related [CVE](https://unit42.paloaltonetworks.com/jsonwebtoken-vulnerability-cve-2022-23529/) because of the fact that `jsonwebtoken` is a devDependency of `@auth0/auth0-spa-js`, we are cutting a release to ensure build tools no longer report our SDK as vulnerable to the mentioned CVE.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
