### PR TITLE
[SDK-3850] Update links to api reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ For more code samples on how to integrate the **auth0-vue** SDK in your **Vue 3*
 Explore public API's available in auth0-vue.
 
 - [createAuth0](https://auth0.github.io/auth0-vue/functions/createAuth0.html)
-- [createAuthGuard](https://auth0.github.io/auth0-vue/functions/createAuthGuard)
-- [useAuth0](https://auth0.github.io/auth0-vue/functions/useAuth0)
+- [createAuthGuard](https://auth0.github.io/auth0-vue/functions/createAuthGuard.html)
+- [useAuth0](https://auth0.github.io/auth0-vue/functions/useAuth0.html)
 - [Auth0PluginOptions](https://auth0.github.io/auth0-vue/interfaces/Auth0PluginOptions.html)
 - [Auth0VueClientOptions](https://auth0.github.io/auth0-vue/interfaces/Auth0VueClientOptions.html)
 - [Auth0VueClient](https://auth0.github.io/auth0-vue/interfaces/Auth0VueClient.html)

--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ For more code samples on how to integrate the **auth0-vue** SDK in your **Vue 3*
 
 Explore public API's available in auth0-vue.
 
-- [createAuth0](https://auth0.github.io/auth0-vue/modules.html#createAuth0)
-- [createAuthGuard](https://auth0.github.io/auth0-vue/modules.html#createAuthGuard)
-- [useAuth0](https://auth0.github.io/auth0-vue/modules.html#useAuth0)
+- [createAuth0](https://auth0.github.io/auth0-vue/functions/createAuth0.html)
+- [createAuthGuard](https://auth0.github.io/auth0-vue/functions/createAuthGuard)
+- [useAuth0](https://auth0.github.io/auth0-vue/functions/useAuth0)
 - [Auth0PluginOptions](https://auth0.github.io/auth0-vue/interfaces/Auth0PluginOptions.html)
 - [Auth0VueClientOptions](https://auth0.github.io/auth0-vue/interfaces/Auth0VueClientOptions.html)
 - [Auth0VueClient](https://auth0.github.io/auth0-vue/interfaces/Auth0VueClient.html)


### PR DESCRIPTION
### Changes

Typedoc changes the structure of some URLs so we need to amend the readme links for that

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
