### PR TITLE
Add exports field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,13 @@
   "main": "dist/lib/auth0-vue.cjs.js",
   "types": "dist/typings/index.d.ts",
   "module": "dist/auth0-vue.production.esm.js",
+  "exports": {
+    ".": {
+      "require": "./dist/lib/auth0-vue.cjs.js",
+      "import": "./dist/auth0-vue.production.esm.js",
+      "types": "./dist/typings/index.d.ts"
+    }
+  },
   "scripts": {
     "dev": "rimraf dist && rollup -c --watch",
     "start": "npm run dev",


### PR DESCRIPTION
### Changes

Adds the `exports` field to package.json as per https://antfu.me/posts/publish-esm-and-cjs and https://nodejs.org/api/packages.html#conditional-exports. This allow tools such as Nuxt to correctly recognize our bundles.

### References

#197 

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
