### PR TITLE
Map redirect_uri on config to authorizationParams

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   Auth0VueClientOptions
 } from './global';
 import { AUTH0_INJECTION_KEY, AUTH0_TOKEN } from './token';
+import { deprecateRedirectUri } from './utils';
 
 export * from './global';
 export { AUTH0_INJECTION_KEY } from './token';
@@ -28,6 +29,7 @@ export function createAuth0(
   clientOptions: Auth0VueClientOptions,
   pluginOptions?: Auth0PluginOptions
 ) {
+  deprecateRedirectUri(clientOptions);
   return new Auth0Plugin(clientOptions, pluginOptions);
 }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -7,7 +7,7 @@ import type {
   Auth0VueClient,
   Auth0VueClientOptions,
   LogoutOptions,
-  RedirectLoginOptions,
+  RedirectLoginOptions
 } from './interfaces';
 import { AUTH0_INJECTION_KEY, AUTH0_TOKEN } from './token';
 import version from './version';
@@ -18,13 +18,10 @@ import type {
   IdToken,
   PopupConfigOptions,
   PopupLoginOptions,
-  RedirectLoginResult,
+  RedirectLoginResult
 } from '@auth0/auth0-spa-js';
-import {
-  Auth0Client,
-  User
-} from '@auth0/auth0-spa-js';
-import { bindPluginMethods } from './utils';
+import { Auth0Client, User } from '@auth0/auth0-spa-js';
+import { bindPluginMethods, deprecateRedirectUri } from './utils';
 
 /**
  * @ignore
@@ -76,6 +73,7 @@ export class Auth0Plugin implements Auth0VueClient {
   }
 
   async loginWithRedirect(options?: RedirectLoginOptions<AppState>) {
+    deprecateRedirectUri(options);
     return this._client.loginWithRedirect(options);
   }
 
@@ -83,6 +81,7 @@ export class Auth0Plugin implements Auth0VueClient {
     options?: PopupLoginOptions,
     config?: PopupConfigOptions
   ) {
+    deprecateRedirectUri(options);
     return this.__proxy(() => this._client.loginWithPopup(options, config));
   }
 
@@ -106,6 +105,7 @@ export class Auth0Plugin implements Auth0VueClient {
   async getAccessTokenSilently(
     options: GetTokenSilentlyOptions = {}
   ): Promise<string | GetTokenSilentlyVerboseResponse> {
+    deprecateRedirectUri(options);
     return this.__proxy(() => this._client.getTokenSilently(options));
   }
 
@@ -113,6 +113,7 @@ export class Auth0Plugin implements Auth0VueClient {
     options?: GetTokenWithPopupOptions,
     config?: PopupConfigOptions
   ) {
+    deprecateRedirectUri(options);
     return this.__proxy(() => this._client.getTokenWithPopup(options, config));
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,7 +31,23 @@ export function watchEffectOnce<T>(watcher: () => T, fn: Function) {
  */
 export function bindPluginMethods(plugin: any, exclude: string[]) {
   Object.getOwnPropertyNames(Object.getPrototypeOf(plugin))
-    .filter(method => !exclude.includes(method)) 
+    .filter(method => !exclude.includes(method))
     // eslint-disable-next-line security/detect-object-injection
-    .forEach(method => (plugin[method] = plugin[method].bind(plugin))); 
+    .forEach(method => (plugin[method] = plugin[method].bind(plugin)));
+}
+
+/**
+ * @ignore
+ * Helper function to map the v1 `redirect_uri` option to the v2 `authorizationParams.redirect_uri`
+ * and log a warning.
+ */
+export function deprecateRedirectUri(options?: any) {
+  if (options?.redirect_uri) {
+    console.warn(
+      'Using `redirect_uri` has been deprecated, please use `authorizationParams.redirect_uri` instead as `redirectUri` will be no longer supported in a future version'
+    );
+    options.authorizationParams = options.authorizationParams || {};
+    options.authorizationParams.redirect_uri = options.redirect_uri;
+    delete options.redirect_uri;
+  }
 }


### PR DESCRIPTION
### Changes

Similar to auth0/auth0-react/pull/507 this adds a conversion of `redirect_uri` on the root of config to `authorizationParams.redirect_uri` to ease the transition for folks who might miss the migration note.

All methods that took a `redirect_uri` have been updated to log a warning and set the property to the new way.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
