### PR TITLE
Gracefully handle errors upon plugin installation

### DIFF
--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -436,6 +436,60 @@ describe('Auth0Plugin', () => {
     });
   });
 
+  it('should call the router, if provided, with the default path when no appState', async () => {
+    const routerPushMock = jest.fn();
+    const plugin = createAuth0({
+      domain: '',
+      clientId: ''
+    });
+
+    appMock.config.globalProperties['$router'] = {
+      push: routerPushMock
+    } as unknown as Router;
+
+    handleRedirectCallbackMock.mockResolvedValue({});
+
+    const urlParams = new URLSearchParams(window.location.search);
+
+    urlParams.set('code', '123');
+    urlParams.set('state', 'xyz');
+
+    window.location.search = urlParams as any;
+
+    plugin.install(appMock);
+
+    return flushPromises().then(() => {
+      expect(routerPushMock).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('should call the router, if provided, with the default path when handleRedirectCallback returns undefined', async () => {
+    const routerPushMock = jest.fn();
+    const plugin = createAuth0({
+      domain: '',
+      clientId: ''
+    });
+
+    appMock.config.globalProperties['$router'] = {
+      push: routerPushMock
+    } as unknown as Router;
+
+    handleRedirectCallbackMock.mockResolvedValue(undefined);
+
+    const urlParams = new URLSearchParams(window.location.search);
+
+    urlParams.set('code', '123');
+    urlParams.set('state', 'xyz');
+
+    window.location.search = urlParams as any;
+
+    plugin.install(appMock);
+
+    return flushPromises().then(() => {
+      expect(routerPushMock).toHaveBeenCalledWith('/');
+    });
+  });
+
   it('should proxy loginWithRedirect', async () => {
     const plugin = createAuth0({
       domain: '',

--- a/playground/auth0.ts
+++ b/playground/auth0.ts
@@ -9,12 +9,15 @@ const domain = res?.domain || defaultDomain;
 const clientId = res?.client_id || defaultClientId;
 const audience = res?.audience || defaultAudience;
 
-export const auth0 = createAuth0({
-  domain,
-  clientId,
-  authorizationParams: {
-    audience,
-    redirect_uri: window.location.origin,
+export const auth0 = createAuth0(
+  {
+    domain,
+    clientId,
+    authorizationParams: {
+      audience,
+      redirect_uri: window.location.origin
+    },
+    useFormData: res?.useFormData || true
   },
-  useFormData: res?.useFormData || true,
-});
+  { errorPath: '/error' }
+);

--- a/playground/components/Error.vue
+++ b/playground/components/Error.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { useAuth0 } from '../../src';
+
+const { error } = useAuth0();
+</script>
+
+<template>
+  <div class="container">
+    <div class="row align-items-center profile-header">
+      <div class="col-12 my-3">
+        <h3>Last error</h3>
+        <pre><code data-cy="error">
+{{JSON.stringify(error, null, 2)}}
+              </code>
+          </pre>
+      </div>
+    </div>
+  </div>
+</template>
+

--- a/playground/components/Home.vue
+++ b/playground/components/Home.vue
@@ -262,7 +262,7 @@ export default {
         auth0.logout({
           openUrl: false,
           logoutParams: {
-            returnTo: window.location.origin,
+            returnTo: window.location.origin
           }
         });
       },
@@ -275,8 +275,8 @@ export default {
         getAccessTokenSilentlyOutsideComponent({
           authorizationParams: {
             audience,
-            scope,
-          },
+            scope
+          }
         }).then(function (token: string) {
           access_tokens.push({
             token: obfuscateToken(token),
@@ -294,8 +294,8 @@ export default {
           .getAccessTokenSilently({
             authorizationParams: {
               audience,
-              scope,
-            },
+              scope
+            }
           })
           .then(function (token: string) {
             access_tokens.push({
@@ -310,11 +310,11 @@ export default {
         access_tokens: any[]
       ) {
         auth0
-          .getAccessTokenWithPopup({ 
+          .getAccessTokenWithPopup({
             authorizationParams: {
               audience,
-              scope,
-            },
+              scope
+            }
           })
           .then(function (token: string) {
             access_tokens.push({

--- a/playground/router.ts
+++ b/playground/router.ts
@@ -6,6 +6,8 @@ import Home from './components/Home.vue';
 // Fix for https://github.com/ezolenko/rollup-plugin-typescript2/issues/129#issuecomment-454558185
 // @ts-ignore
 import Profile from './components/Profile.vue';
+// @ts-ignore
+import Error from './components/Error.vue';
 
 export function createRouter({ client_id, domain, audience }: any) {
   return createVueRouter({
@@ -26,6 +28,11 @@ export function createRouter({ client_id, domain, audience }: any) {
         name: 'profile',
         component: Profile,
         beforeEnter: authGuard
+      },
+      {
+        path: '/error',
+        name: 'error',
+        component: Error
       }
     ],
     history: createWebHistory()

--- a/src/interfaces/auth0-plugin-options.ts
+++ b/src/interfaces/auth0-plugin-options.ts
@@ -21,4 +21,10 @@ export interface Auth0PluginOptions {
    *
    */
   skipRedirectCallback?: boolean;
+
+  /**
+   * Path in your application to redirect to when the Authorization server
+   * returns an error. Defaults to `/`
+   */
+  errorPath?: string;
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -132,24 +132,29 @@ export class Auth0Plugin implements Auth0VueClient {
   private async __checkSession(router?: Router) {
     const search = window.location.search;
 
-    if (
-      (search.includes('code=') || search.includes('error=')) &&
-      search.includes('state=') &&
-      !this.pluginOptions?.skipRedirectCallback
-    ) {
-      const result = await this.handleRedirectCallback();
-      const appState = result?.appState;
-      const target = appState?.target ?? '/';
+    try {
+      if (
+        (search.includes('code=') || search.includes('error=')) &&
+        search.includes('state=') &&
+        !this.pluginOptions?.skipRedirectCallback
+      ) {
+        const result = await this.handleRedirectCallback();
+        const appState = result?.appState;
+        const target = appState?.target ?? '/';
 
-      window.history.replaceState({}, '', '/');
+        window.history.replaceState({}, '', '/');
 
-      if (router) {
-        router.push(target);
+        if (router) {
+          router.push(target);
+        }
+
+        return result;
+      } else {
+        await this.checkSession();
       }
-
-      return result;
-    } else {
-      await this.checkSession();
+    } catch (e) {
+      // Check Session should never throw an exception as it will fail installing the plugin.
+      // Instead, errors during checkSession are propagated using the errors property on `useAuth0`.
     }
   }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -153,8 +153,8 @@ export class Auth0Plugin implements Auth0VueClient {
         await this.checkSession();
       }
     } catch (e) {
-      // Check Session should never throw an exception as it will fail installing the plugin.
-      // Instead, errors during checkSession are propagated using the errors property on `useAuth0`.
+      // __checkSession should never throw an exception as it will fail installing the plugin.
+      // Instead, errors during __checkSession are propagated using the errors property on `useAuth0`.
 
       window.history.replaceState({}, '', '/');
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -155,6 +155,12 @@ export class Auth0Plugin implements Auth0VueClient {
     } catch (e) {
       // Check Session should never throw an exception as it will fail installing the plugin.
       // Instead, errors during checkSession are propagated using the errors property on `useAuth0`.
+
+      window.history.replaceState({}, '', '/');
+
+      if (router) {
+        router.push(this.pluginOptions?.errorPath || '/');
+      }
     }
   }
 


### PR DESCRIPTION
### Changes

__checkSession is a private method that is only called when the plugin is being installed.
We should ensure errors are not thrown as that would fail running the application and installing the plugin.

Instead, errors are available using the `errors` property on the plugin.

On top of that, we added the possibility to provide an errorPath to control where the SDK should redirect to when an error occured. If omitted, our SDK will redirect back to `/` when an error occured.

### References

Closes #223 

### Testing

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
