### PR TITLE
fix redirect to appState.target in __checkSession

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -142,7 +142,7 @@ export class Auth0Plugin implements Auth0VueClient {
         const appState = result?.appState;
         const target = appState?.target ?? '/';
 
-        window.history.replaceState({}, '', '/');
+        window.history.replaceState({}, '', target);
 
         if (router) {
           router.push(target);


### PR DESCRIPTION
### Changes

__checkSession always replaced the window history state with the root path ('/') regardless of the actual target. This pull request fixes the issue by using the correct target path when updating the window history state.

### References

https://community.auth0.com/t/url-replace-after-loginwithredirect/97928

### Testing

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
