### PR TITLE
Avoid using readonly for public exposed reactive properties

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,5 +1,5 @@
 import type { App, Ref } from 'vue';
-import { reactive, readonly, ref } from 'vue';
+import { ref } from 'vue';
 import type { Router } from 'vue-router';
 import type {
   AppState,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,5 +1,5 @@
 import type { App, Ref } from 'vue';
-import { readonly, ref } from 'vue';
+import { reactive, readonly, ref } from 'vue';
 import type { Router } from 'vue-router';
 import type {
   AppState,
@@ -62,17 +62,11 @@ export const client: Ref<Auth0VueClient> = ref(
  */
 export class Auth0Plugin implements Auth0VueClient {
   private _client!: Auth0Client;
-  private _isLoading: Ref<boolean> = ref(true);
-  private _isAuthenticated: Ref<boolean> = ref(false);
-  private _user: Ref<User | undefined> = ref({});
-  private _idTokenClaims = ref<IdToken>();
-  private _error = ref<Error | null>(null);
-
-  isLoading = readonly(this._isLoading);
-  isAuthenticated = readonly(this._isAuthenticated);
-  user = readonly(this._user);
-  idTokenClaims = readonly(this._idTokenClaims);
-  error = readonly(this._error);
+  public isLoading: Ref<boolean> = ref(true);
+  public isAuthenticated: Ref<boolean> = ref(false);
+  public user: Ref<User | undefined> = ref({});
+  public idTokenClaims = ref<IdToken | undefined>();
+  public error = ref<Error | null>(null);
 
   constructor(
     private clientOptions: Auth0VueClientOptions,
@@ -194,19 +188,19 @@ export class Auth0Plugin implements Auth0VueClient {
   }
 
   private async __refreshState() {
-    this._isAuthenticated.value = await this._client.isAuthenticated();
-    this._user.value = await this._client.getUser();
-    this._idTokenClaims.value = await this._client.getIdTokenClaims();
-    this._isLoading.value = false;
+    this.isAuthenticated.value = await this._client.isAuthenticated();
+    this.user.value = await this._client.getUser();
+    this.idTokenClaims.value = await this._client.getIdTokenClaims();
+    this.isLoading.value = false;
   }
 
   private async __proxy<T>(cb: () => T, refreshState = true) {
     let result;
     try {
       result = await cb();
-      this._error.value = null;
+      this.error.value = null;
     } catch (e) {
-      this._error.value = e as Error;
+      this.error.value = e as Error;
       throw e;
     } finally {
       if (refreshState) {


### PR DESCRIPTION
### Changes

Using `readonly()` kinda changes the types in such a way that it marks all properties as readonly. Instead of actual IdToken (or User) types, it's actualy using an inline type based on the IdToken (but marking everything as readonly).

This means that the Auth0VueClient interface defined properties such as IdTokenClaims as a `Ref<IdToken | undefined>`, the Auth0VuePlugin has them being inferred to as `DeepReadonly<UnwrapNestedRefs<IdToken>>`, which doesn't always align.

This can become complicated to type properly, while they don't really need to be marked as read-only. 

Dropping the read-only shouldn't cause issues, as they share the same public API:

```ts
const x = ref<IdToken>({__raw: 'abc'});
const xReadOnly = readonly(x);

console.log('raw', { x, xReadOnly }); // Logs x: RefImpl and xReadOnly: Proxy(RefImpl)
console.log('value', { x: x.value, xReadOnly: xReadOnly?.value }); // Logs 2x Proxy(Object)
console.log('property', { x: x.value.__raw, xReadOnly: xReadOnly?.value.__raw }); // Logs 2x 'abc'
```

With our SDK, the above would be:

```ts
console.log(auth0.idTokenClaims); // Logs RefImpl after this PR, Proxy(RefImpl) before this PR.
console.log(auth0.idTokenClaims.value); // Logs Proxy(Object) before and after this PR.
console.log(auth0.idTokenClaims.value.name); // Logs the correct claim value before and after this PR
```

As you can see, this should not change anything in how users can interact with our public reactive API.

### References

Closes #240 

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
