### PR TITLE
bump auth0-spa-js to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
-        "@auth0/auth0-spa-js": "^2.1.1",
+        "@auth0/auth0-spa-js": "^2.1.2",
         "vue": "^3.2.41"
       },
       "devDependencies": {
@@ -78,9 +78,9 @@
       }
     },
     "node_modules/@auth0/auth0-spa-js": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.1.1.tgz",
-      "integrity": "sha512-21qEf5Bjouy76CWd1gQgf/tT6iD513YFYaK0+3OF1nbwLtPFpxm5Ln94M7SCVFKfe5jbchWuEcIb1HLer3r6RA=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.1.2.tgz",
+      "integrity": "sha512-xdA65Z/U7++Y7L9Uwh8Q8OVOs6qgFz+fb7GAzHFjpr1icO37B//xdzLXm7ZRgA19RWrsNe1nme3h896igJSvvw=="
     },
     "node_modules/@auth0/component-cdn-uploader": {
       "version": "2.2.2",
@@ -14876,9 +14876,9 @@
       }
     },
     "@auth0/auth0-spa-js": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.1.1.tgz",
-      "integrity": "sha512-21qEf5Bjouy76CWd1gQgf/tT6iD513YFYaK0+3OF1nbwLtPFpxm5Ln94M7SCVFKfe5jbchWuEcIb1HLer3r6RA=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.1.2.tgz",
+      "integrity": "sha512-xdA65Z/U7++Y7L9Uwh8Q8OVOs6qgFz+fb7GAzHFjpr1icO37B//xdzLXm7ZRgA19RWrsNe1nme3h896igJSvvw=="
     },
     "@auth0/component-cdn-uploader": {
       "version": "git+ssh://git@github.com/auth0/component-cdn-uploader.git#c86a1f043b9f30b3a3407b19b2e6cd9f1ccdc21b",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "wait-on": "^6.0.0"
   },
   "dependencies": {
-    "@auth0/auth0-spa-js": "^2.1.1",
+    "@auth0/auth0-spa-js": "^2.1.2",
     "vue": "^3.2.41"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description

Bumps SPA-JS to v2.1.2 to include the fix for organizations.

### References

https://github.com/auth0/auth0-spa-js/releases/tag/v2.1.2

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
