### PR TITLE
Use export type and import type to allow verbatimModuleSyntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "ts-jest": "^29.0.3",
         "tslib": "^2.3.1",
         "typedoc": "^0.25.1",
-        "typescript": "^4.9.3",
+        "typescript": "^5.2.2",
         "vue-router": "^4.0.12",
         "wait-on": "^6.0.0"
       },
@@ -14815,16 +14815,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbzip2-stream": {
@@ -27146,9 +27146,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "devOptional": true
     },
     "unbzip2-stream": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "ts-jest": "^29.0.3",
     "tslib": "^2.3.1",
     "typedoc": "^0.25.1",
-    "typescript": "^4.9.3",
+    "typescript": "^5.2.2",
     "vue-router": "^4.0.12",
     "wait-on": "^6.0.0"
   },

--- a/playground/api.ts
+++ b/playground/api.ts
@@ -1,4 +1,4 @@
-import { GetTokenSilentlyOptions } from '@auth0/auth0-spa-js';
+import type { GetTokenSilentlyOptions } from '@auth0/auth0-spa-js';
 import { auth0 } from './auth0';
 
 export async function getAccessTokenSilentlyOutsideComponent(

--- a/src/global.ts
+++ b/src/global.ts
@@ -2,7 +2,9 @@ export { Auth0Plugin } from './plugin';
 export * from './interfaces';
 export * from './guard';
 
-export {
+export { User, InMemoryCache, LocalStorageCache } from '@auth0/auth0-spa-js';
+
+export type {
   AuthorizationParams,
   PopupLoginOptions,
   PopupConfigOptions,
@@ -11,9 +13,6 @@ export {
   CacheLocation,
   GetTokenSilentlyOptions,
   IdToken,
-  User,
   ICache,
-  InMemoryCache,
-  LocalStorageCache,
-  Cacheable,
+  Cacheable
 } from '@auth0/auth0-spa-js';

--- a/src/guard.ts
+++ b/src/guard.ts
@@ -5,7 +5,7 @@ import { AUTH0_TOKEN } from './token';
 import type { Auth0VueClient } from './interfaces';
 import type { App } from 'vue';
 import { unref } from 'vue';
-import { RedirectLoginOptions } from '@auth0/auth0-spa-js';
+import type { RedirectLoginOptions } from '@auth0/auth0-spa-js';
 
 async function createGuardHandler(
   client: Auth0VueClient,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { inject } from 'vue';
 import './global';
-import {
+import { Auth0Plugin } from './global';
+import type {
   Auth0VueClient,
-  Auth0Plugin,
   Auth0PluginOptions,
   Auth0VueClientOptions
 } from './global';

--- a/src/interfaces/auth0-vue-client-options.ts
+++ b/src/interfaces/auth0-vue-client-options.ts
@@ -4,7 +4,7 @@ import type {
   LogoutOptions as SPALogoutOptions,
   RedirectLoginOptions as SPARedirectLoginOptions
 } from '@auth0/auth0-spa-js';
-import { AppState } from './app-state';
+import type { AppState } from './app-state';
 
 /**
  * Configuration for the Auth0 Vue Client

--- a/src/interfaces/auth0-vue-client.ts
+++ b/src/interfaces/auth0-vue-client.ts
@@ -11,7 +11,7 @@ import type {
 } from '@auth0/auth0-spa-js';
 import type { Ref } from 'vue';
 import type { AppState } from './app-state';
-import {
+import type {
   LogoutOptions,
   RedirectLoginOptions
 } from './auth0-vue-client-options';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "moduleResolution": "node",
     "noImplicitAny": true,
     "downlevelIteration": true,
-    "strict": true
+    "strict": true,
+    "verbatimModuleSyntax": true
   },
   "exclude": [
     "./__tests__",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noImplicitAny": false,
-    "target": "es6"
+    "target": "es6",
+    "verbatimModuleSyntax": false
   }
 }


### PR DESCRIPTION
### Changes

Correctly export and import types to allow verbatimModuleSyntax

### References

Closes #302 

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
