### PR TITLE
Update example for skipRedirectCallback

### DIFF
--- a/src/interfaces/auth0-plugin-options.ts
+++ b/src/interfaces/auth0-plugin-options.ts
@@ -11,7 +11,7 @@ export interface Auth0PluginOptions {
    * In these cases you can instruct the client to ignore certain URLs by setting `skipRedirectCallback`.
    *
    * ```js
-   * createAuth0({
+   * createAuth0({}, {
    *   skipRedirectCallback: window.location.pathname === '/other-callback'
    * })
    * ```


### PR DESCRIPTION
### Changes

The sample for using skipRedirectCallback is incorrect, as plugin options are the second argument.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
