### PR TITLE
Add Skip the Auth0 login page to FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -7,6 +7,7 @@
 3. [User is redirected to `/` after successful sign in with redirect](#3-user-is-redirected-to--after-successful-sign-in-with-redirect)
 4. [Getting an infinite redirect loop between my application and Auth0](#4-getting-an-infinite-redirect-loop-between-my-application-and-auth0)
 5. [Accessing information outside of the context of a component](#5-accessing-information-outside-of-the-context-of-a-component)
+6. [Skip the Auth0 login page](#6-skip-the-auth0-login-page)
 
 ## 1. User is not logged in after page refresh
 
@@ -117,3 +118,33 @@ An example would be to access the user's name, you would use [`toRaw`](https://v
 const user = toRaw(auth0.user).value;
 console.log(user.name);
 ```
+
+## 6. Skip the Auth0 login page
+
+When integrating with third party providers such as Google or Microsoft, being redirected to Auth0 before being redirected to the corresponding provider can be sub-optimal in terms of user-experience.
+If you only have a single connection enabled, or you know up front how the user wants to authenticate, you can set the `connection` parameter when calling `loginWithRedirect()` or `loginWithPopup()`:
+
+```js
+loginWithRedirect({
+  // ...
+  authorizationParams: {
+    connection: 'connection_logical_identifier'
+  }
+})
+```
+
+Doing so for connections such as Google or Microsoft, would automatically redirect you to them instead of showing the Auth0 login page first.
+
+Additionally, if you are using our AuthGuard, you may want it to pick up the same connection when it would redirect for login. To do so, you should provide the `connection` property when creating the AuthGuard using `createAuthGuard`:
+
+```js
+const guard = createAuthGuard({
+  redirectLoginOptions: {
+    authorizationParams: {
+      connection: 'connection_logical_identifier'
+    }
+  }
+})
+```
+
+ℹ️ You can find the connection's logical identifier as the **connection name** in the connection settings in the Auth0 dashboard for your tenant.


### PR DESCRIPTION
### Changes

Adds an additional entry to the FAQ about skipping the Auth0 login page, after having a conversation with someone that was confused about this.

### References

N/A

### Testing

N/A

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
