### PR TITLE
Run CI on node 20 with 18 being EOL

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -5,7 +5,7 @@ inputs:
   node:
     description: The Node version to use
     required: false
-    default: 18
+    default: 20
 
 runs:
   using: composite

--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  NODE_VERSION: 18
+  NODE_VERSION: 20
   CACHE_KEY: '${{ github.event.pull_request.head.sha || github.ref }}-${{ github.run_id }}-${{ github.run_attempt }}'
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
   rl-scanner:
     uses: ./.github/workflows/rl-secure.yml
     with:
-      node-version: 18 ## depends if build requires node else we can remove this.
+      node-version: 20 ## depends if build requires node else we can remove this.
       artifact-name: 'auth0-vue.tgz' ## Will change respective to Repository 
     secrets:
       RLSECURE_LICENSE: ${{ secrets.RLSECURE_LICENSE }}
@@ -32,7 +32,7 @@ jobs:
     uses: ./.github/workflows/npm-release.yml
     needs: rl-scanner ## this is important as this will not let release job to run until rl-scanner is done
     with:
-      node-version: 18
+      node-version: 20
       require-build: true
     secrets:
       npm-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  NODE_VERSION: 18
+  NODE_VERSION: 20
   CACHE_KEY: '${{ github.ref }}-${{ github.run_id }}-${{ github.run_attempt }}'
 
 jobs:


### PR DESCRIPTION
With Node.js 18 being end of life, we want to stop running CI on node 18.