### PR TITLE
fix: merge appState in Auth Guard

### DIFF
--- a/src/guard.ts
+++ b/src/guard.ts
@@ -18,8 +18,11 @@ async function createGuardHandler(
     }
 
     await client.loginWithRedirect({
-      appState: { target: to.fullPath },
-      ...redirectLoginOptions
+      ...redirectLoginOptions,
+      appState: {
+        target: to.fullPath,
+        ...redirectLoginOptions?.appState
+      }
     });
 
     return false;
@@ -44,7 +47,9 @@ export interface AuthGuardOptions {
   app?: App;
 
   /**
-   * Route specific options to use when being redirected to Auth0
+   * Route specific options to use when being redirected to Auth0.
+   * If appState is provided, it will be merged with the guard's automatic
+   * target property. The guard's target always takes precedence.
    */
   redirectLoginOptions?: RedirectLoginOptions;
 }

--- a/src/guard.ts
+++ b/src/guard.ts
@@ -49,7 +49,7 @@ export interface AuthGuardOptions {
   /**
    * Route specific options to use when being redirected to Auth0.
    * If appState is provided, it will be merged with the guard's automatic
-   * target property. The guard's target always takes precedence.
+   * target property. Any target provided in appState will take precedence over the guard's default target.
    */
   redirectLoginOptions?: RedirectLoginOptions;
 }


### PR DESCRIPTION
### Changes

When a user would provide `appState` on `redirectLoginOptions` when creating the Auth Guard, we would lose any `appState.target` value, due to the fact that this was not being accounted for.

### References

Closes #434 

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
