### PR TITLE
fix: ensure to use pathname instead of '/' when clearing query parameters

### DIFF
--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -518,6 +518,44 @@ describe('Auth0Plugin', () => {
     });
   });
 
+  it('should preserve pathname when calling replaceState for subdirectory deployments', async () => {
+    const plugin = createAuth0({
+      domain: '',
+      clientId: ''
+    });
+
+    // Simulate subdirectory deployment
+    delete (window as any).location;
+    const mockLocation = {
+      href: 'https://example.org/subdir?code=123&state=xyz',
+      origin: 'https://example.org',
+      protocol: 'https:',
+      host: 'example.org',
+      hostname: 'example.org',
+      port: '',
+      pathname: '/subdir',
+      search: '?code=123&state=xyz',
+      hash: '',
+      ancestorOrigins: '',
+      assign: jest.fn(),
+      reload: jest.fn(),
+      replace: jest.fn()
+    };
+    window.location = mockLocation as any;
+
+    handleRedirectCallbackMock.mockResolvedValue({
+      appState: { target: '/dashboard' }
+    });
+
+    plugin.install(appMock);
+
+    expect.assertions(1);
+
+    return flushPromises().then(() => {
+      expect(replaceStateMock).toHaveBeenCalledWith({}, '', '/subdir');
+    });
+  });
+
   it('should proxy loginWithRedirect', async () => {
     const plugin = createAuth0({
       domain: '',

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -198,7 +198,8 @@ export class Auth0Plugin implements Auth0VueClient {
         const appState = result?.appState;
         const target = appState?.target ?? '/';
 
-        window.history.replaceState({}, '', '/');
+        // Remove query parameters from the URL, keeping the exact pathname.
+        window.history.replaceState({}, '', window.location.pathname);
 
         if (router) {
           router.push(target);


### PR DESCRIPTION
### Changes

Using `window.history.replaceState({}, '', '/');` can, and will cause issues when the application is not served from root.

That particular code has the only purpose to remove the query string, not change the URL. Changing the URL happens only when we are using the router.

Whenever a user would handle the code exchange on `https://example.com/foo?code=abc`, we would update the URL to be `https://example.com`, instead of `https://example.com/foo`.

### References

Closes #424 

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
