### PR TITLE
fix(security): add .npmrc with ignore-scripts=true

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
This prevents malicious postinstall scripts from running during `npm install`, both in CI and locally.

### Changes

- Added `.npmrc` with `ignore-scripts=true`