### PR TITLE
feat: add Multi-Factor Authentication (MFA) support

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1303,10 +1303,15 @@ Use the challenge flow when the user already has an enrolled authenticator.
       const recoveryCode = ref('');
 
       const verifyRecoveryCode = async (mfaToken) => {
-        await mfa.verify({
+        const tokens = await mfa.verify({
           mfaToken,
           recoveryCode: recoveryCode.value
         });
+        // Auth0 rotates the recovery code on use — save the replacement or the
+        // user will be locked out if they need to fall back again.
+        if (tokens.recovery_code) {
+          console.warn('Save your new recovery code:', tokens.recovery_code);
+        }
         // Refresh Vue reactive state (isAuthenticated, user, etc.)
         await checkSession();
       };

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1440,6 +1440,8 @@ The `mfa` client throws typed errors for each operation:
               console.error('Enrollment failed:', mfaError.error_description);
             } else if (mfaError instanceof MfaChallengeError) {
               console.error('Challenge failed:', mfaError.error_description);
+            } else if (mfaError instanceof MfaEnrollmentFactorsError) {
+              console.error('Failed to retrieve enrollment factors:', mfaError.error_description);
             }
           }
         }

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -11,6 +11,8 @@
 - [Accessing Auth0Client outside of a component](#accessing-auth0client-outside-of-a-component)
 - [Organizations](#organizations)
 - [Device-bound tokens with DPoP](#device-bound-tokens-with-dpop)
+- [Multi-Factor Authentication (MFA)](#multi-factor-authentication-mfa)
+- [Step-Up Authentication](#step-up-authentication)
 
 ## Add login to your application
 
@@ -1144,4 +1146,402 @@ For scenarios requiring full control over DPoP proof generation and nonce manage
 ```
 
 </details>
+
+## Multi-Factor Authentication (MFA)
+
+The `mfa` property on the object returned by `useAuth0` gives access to all MFA operations. MFA flows are triggered when `getAccessTokenSilently` throws a `MfaRequiredError`.
+
+> **Prerequisites:** MFA requires refresh token rotation to be enabled in the Auth0 client configuration (`useRefreshTokens: true`).
+
+### Setup
+
+Configure your Auth0 client with refresh tokens:
+
+```js
+import { createAuth0 } from '@auth0/auth0-vue';
+
+const app = createApp(App);
+
+app.use(
+  createAuth0({
+    domain: '<AUTH0_DOMAIN>',
+    clientId: '<AUTH0_CLIENT_ID>',
+    authorizationParams: {
+      redirect_uri: window.location.origin
+    },
+    useRefreshTokens: true
+  })
+);
+```
+
+### Handling the MFA Required Error
+
+When `getAccessTokenSilently` results in an MFA requirement, it throws `MfaRequiredError`. Check `mfa_requirements.enroll` first — if it is non-empty the user must enroll a new factor before they can authenticate; otherwise proceed with a challenge against an existing authenticator:
+
+```html
+<script>
+  import { useAuth0, MfaRequiredError } from '@auth0/auth0-vue';
+  import { ref } from 'vue';
+
+  export default {
+    setup() {
+      const { getAccessTokenSilently, mfa } = useAuth0();
+      const mfaToken = ref(null);
+
+      const fetchToken = async () => {
+        try {
+          const token = await getAccessTokenSilently({
+            authorizationParams: { audience: 'https://api.example.com' }
+          });
+          console.log('Access token:', token);
+        } catch (e) {
+          if (e instanceof MfaRequiredError) {
+            mfaToken.value = e.mfa_token;
+
+            if (e.mfa_requirements?.enroll?.length) {
+              // User has no authenticators yet — show enrollment UI
+              const factors = await mfa.getEnrollmentFactors(e.mfa_token);
+              // present factors to the user (see Enrollment Flow below)
+            } else {
+              // User is already enrolled — show challenge UI
+              const authenticators = await mfa.getAuthenticators(e.mfa_token);
+              // present authenticators to the user (see Challenge Flow below)
+            }
+          }
+        }
+      };
+
+      return { fetchToken, mfaToken };
+    }
+  };
+</script>
+```
+
+### Challenge Flow
+
+Use the challenge flow when the user already has an enrolled authenticator.
+
+> **Note:** `mfa.verify()` returns raw tokens but does **not** automatically update Vue's reactive state (`isAuthenticated`, `user`, `idTokenClaims`). Call `checkSession()` after a successful `verify()` to refresh the auth state in your components.
+
+#### OTP (TOTP / Authenticator App)
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+  import { ref } from 'vue';
+
+  export default {
+    setup() {
+      const { mfa, checkSession } = useAuth0();
+      const otpCode = ref('');
+
+      const verifyOtp = async (mfaToken) => {
+        // For OTP, no challenge call is required — the user enters
+        // the code directly from their authenticator app.
+        await mfa.verify({
+          mfaToken,
+          otp: otpCode.value
+        });
+        // Refresh Vue reactive state (isAuthenticated, user, etc.)
+        await checkSession();
+      };
+
+      return { otpCode, verifyOtp };
+    }
+  };
+</script>
+```
+
+#### SMS / Email OTP
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+  import { ref } from 'vue';
+
+  export default {
+    setup() {
+      const { mfa, checkSession } = useAuth0();
+      const bindingCode = ref('');
+      const oobCode = ref('');
+
+      const sendChallenge = async (mfaToken, authenticatorId) => {
+        const challenge = await mfa.challenge({
+          mfaToken,
+          challengeType: 'oob',
+          authenticatorId
+        });
+        oobCode.value = challenge.oobCode;
+      };
+
+      const verifyOob = async (mfaToken) => {
+        await mfa.verify({
+          mfaToken,
+          oobCode: oobCode.value,
+          bindingCode: bindingCode.value
+        });
+        // Refresh Vue reactive state (isAuthenticated, user, etc.)
+        await checkSession();
+      };
+
+      return { bindingCode, oobCode, sendChallenge, verifyOob };
+    }
+  };
+</script>
+```
+
+#### Recovery Code
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+  import { ref } from 'vue';
+
+  export default {
+    setup() {
+      const { mfa, checkSession } = useAuth0();
+      const recoveryCode = ref('');
+
+      const verifyRecoveryCode = async (mfaToken) => {
+        await mfa.verify({
+          mfaToken,
+          recoveryCode: recoveryCode.value
+        });
+        // Refresh Vue reactive state (isAuthenticated, user, etc.)
+        await checkSession();
+      };
+
+      return { recoveryCode, verifyRecoveryCode };
+    }
+  };
+</script>
+```
+
+### Enrollment Flow
+
+Use the enrollment flow when the user has no authenticators yet. Call `getEnrollmentFactors` to discover what they can enroll in.
+
+#### Discover Enrollment Options
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+  import { ref } from 'vue';
+
+  export default {
+    setup() {
+      const { mfa } = useAuth0();
+      const enrollmentFactors = ref([]);
+
+      const loadEnrollmentOptions = async (mfaToken) => {
+        enrollmentFactors.value = await mfa.getEnrollmentFactors(mfaToken);
+        // e.g. [{ type: 'otp' }, { type: 'phone' }, { type: 'push-notification' }]
+      };
+
+      return { enrollmentFactors, loadEnrollmentOptions };
+    }
+  };
+</script>
+```
+
+#### Enroll TOTP
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+  import { ref } from 'vue';
+
+  export default {
+    setup() {
+      const { mfa } = useAuth0();
+      const barcodeUri = ref('');
+      const secret = ref('');
+
+      const enrollTotp = async (mfaToken) => {
+        const enrollment = await mfa.enroll({
+          mfaToken,
+          factorType: 'otp'
+        });
+        barcodeUri.value = enrollment.barcodeUri; // Render as QR code
+        secret.value = enrollment.secret;         // Show as manual entry fallback
+      };
+
+      return { barcodeUri, secret, enrollTotp };
+    }
+  };
+</script>
+```
+
+#### Enroll SMS
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { mfa } = useAuth0();
+
+      const enrollSms = async (mfaToken, phoneNumber) => {
+        await mfa.enroll({
+          mfaToken,
+          factorType: 'sms',
+          phoneNumber // E.164 format, e.g. '+12025551234'
+        });
+        // An OOB code is sent via SMS — prompt the user to enter it
+      };
+
+      return { enrollSms };
+    }
+  };
+</script>
+```
+
+### Error Handling
+
+The `mfa` client throws typed errors for each operation:
+
+```html
+<script>
+  import {
+    useAuth0,
+    MfaRequiredError,
+    MfaListAuthenticatorsError,
+    MfaEnrollmentError,
+    MfaChallengeError,
+    MfaVerifyError,
+    MfaEnrollmentFactorsError
+  } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { getAccessTokenSilently, mfa } = useAuth0();
+
+      const handleMfaFlow = async () => {
+        try {
+          await getAccessTokenSilently();
+        } catch (e) {
+          if (!(e instanceof MfaRequiredError)) throw e;
+
+          try {
+            const authenticators = await mfa.getAuthenticators(e.mfa_token);
+            // ... drive challenge/enrollment UI
+          } catch (mfaError) {
+            if (mfaError instanceof MfaListAuthenticatorsError) {
+              console.error('Failed to list authenticators:', mfaError.error_description);
+            } else if (mfaError instanceof MfaVerifyError) {
+              console.error('Verification failed:', mfaError.error_description);
+            } else if (mfaError instanceof MfaEnrollmentError) {
+              console.error('Enrollment failed:', mfaError.error_description);
+            } else if (mfaError instanceof MfaChallengeError) {
+              console.error('Challenge failed:', mfaError.error_description);
+            }
+          }
+        }
+      };
+
+      return { handleMfaFlow };
+    }
+  };
+</script>
+```
+
+### Options API
+
+All MFA operations are also available via the Options API using `this.$auth0.mfa`:
+
+```html
+<script>
+  import { MfaRequiredError } from '@auth0/auth0-vue';
+
+  export default {
+    data() {
+      return {
+        mfaToken: null,
+        authenticators: []
+      };
+    },
+    methods: {
+      async fetchToken() {
+        try {
+          await this.$auth0.getAccessTokenSilently({
+            authorizationParams: { audience: 'https://api.example.com' }
+          });
+        } catch (e) {
+          if (e instanceof MfaRequiredError) {
+            this.mfaToken = e.mfa_token;
+            if (e.mfa_requirements?.enroll?.length) {
+              // User needs to enroll — show enrollment UI
+            } else {
+              // User is already enrolled — show challenge UI
+              this.authenticators = await this.$auth0.mfa.getAuthenticators(e.mfa_token);
+            }
+          }
+        }
+      },
+      async verifyOtp(otpCode) {
+        await this.$auth0.mfa.verify({
+          mfaToken: this.mfaToken,
+          otp: otpCode
+        });
+        // Refresh Vue reactive state (isAuthenticated, user, etc.)
+        await this.$auth0.checkSession();
+      }
+    }
+  };
+</script>
+```
+
+## Step-Up Authentication
+
+Step-Up Authentication is an alternative to building a custom MFA UI. When `interactiveErrorHandler: 'popup'` is configured, `getAccessTokenSilently()` automatically handles any `mfa_required` error by opening a Universal Login popup for the user to complete MFA — the token is then returned transparently with no extra code needed in your components.
+
+### Setup
+
+```js
+import { createAuth0 } from '@auth0/auth0-vue';
+
+const app = createApp(App);
+
+app.use(
+  createAuth0({
+    domain: '<AUTH0_DOMAIN>',
+    clientId: '<AUTH0_CLIENT_ID>',
+    authorizationParams: {
+      redirect_uri: window.location.origin
+    },
+    useRefreshTokens: true,
+    interactiveErrorHandler: 'popup'
+  })
+);
+```
+
+### Usage
+
+With `interactiveErrorHandler: 'popup'` set, no special error handling is needed. If Auth0 requires MFA, the SDK opens Universal Login in a popup automatically:
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { getAccessTokenSilently } = useAuth0();
+
+      const fetchToken = async () => {
+        // If MFA is required, the SDK opens a popup automatically.
+        // The token is returned once the user completes authentication.
+        const token = await getAccessTokenSilently({
+          authorizationParams: { audience: 'https://api.example.com' }
+        });
+        console.log('Access token:', token);
+      };
+
+      return { fetchToken };
+    }
+  };
+</script>
+```
+
+If there is a problem with the popup, `getAccessTokenSilently` will throw one of `PopupOpenError`, `PopupCancelledError`, or `PopupTimeoutError`.
 

--- a/__tests__/mfa.test.ts
+++ b/__tests__/mfa.test.ts
@@ -131,6 +131,25 @@ describe('MFA', () => {
 
       expect(auth0.mfa).toBeDefined();
     });
+
+    it('should call mfa methods through the useAuth0 composition API', async () => {
+      const plugin = createAuth0({ domain: '', clientId: '' });
+      plugin.install(appMock);
+
+      (inject as jest.Mock).mockReturnValue(plugin);
+      const auth0 = useAuth0();
+
+      mfaGetAuthenticatorsMock.mockResolvedValue([
+        { id: 'otp|dev_1', authenticatorType: 'otp', active: true }
+      ]);
+
+      const result = await auth0.mfa.getAuthenticators('test-mfa-token');
+
+      expect(mfaGetAuthenticatorsMock).toHaveBeenCalledWith('test-mfa-token');
+      expect(result).toEqual([
+        { id: 'otp|dev_1', authenticatorType: 'otp', active: true }
+      ]);
+    });
   });
 
   describe('mfa methods', () => {
@@ -155,6 +174,13 @@ describe('MFA', () => {
       ]);
     });
 
+    it('should bubble errors from getAuthenticators to the caller', async () => {
+      const errorObj = new Error('getAuthenticators failed');
+      mfaGetAuthenticatorsMock.mockRejectedValue(errorObj);
+
+      await expect(plugin.mfa.getAuthenticators('test-mfa-token')).rejects.toBe(errorObj);
+    });
+
     it('should call enroll on the underlying spa-js mfa client', async () => {
       const enrollParams = { mfaToken: 'test-mfa-token', factorType: 'otp' as const };
       const enrollResponse = {
@@ -168,6 +194,15 @@ describe('MFA', () => {
 
       expect(mfaEnrollMock).toHaveBeenCalledWith(enrollParams);
       expect(result).toEqual(enrollResponse);
+    });
+
+    it('should bubble errors from enroll to the caller', async () => {
+      const errorObj = new Error('enroll failed');
+      mfaEnrollMock.mockRejectedValue(errorObj);
+
+      await expect(
+        plugin.mfa.enroll({ mfaToken: 'test-mfa-token', factorType: 'otp' })
+      ).rejects.toBe(errorObj);
     });
 
     it('should call challenge on the underlying spa-js mfa client', async () => {
@@ -185,6 +220,15 @@ describe('MFA', () => {
       expect(result).toEqual(challengeResponse);
     });
 
+    it('should bubble errors from challenge to the caller', async () => {
+      const errorObj = new Error('challenge failed');
+      mfaChallengeMock.mockRejectedValue(errorObj);
+
+      await expect(
+        plugin.mfa.challenge({ mfaToken: 'test-mfa-token', challengeType: 'otp', authenticatorId: 'otp|dev_1' })
+      ).rejects.toBe(errorObj);
+    });
+
     it('should call verify on the underlying spa-js mfa client', async () => {
       const verifyParams = { mfaToken: 'test-mfa-token', otp: '123456' };
       const tokenResponse = { access_token: 'new-access-token' };
@@ -196,6 +240,15 @@ describe('MFA', () => {
       expect(result).toEqual(tokenResponse);
     });
 
+    it('should bubble errors from verify to the caller', async () => {
+      const errorObj = new Error('verify failed');
+      mfaVerifyMock.mockRejectedValue(errorObj);
+
+      await expect(
+        plugin.mfa.verify({ mfaToken: 'test-mfa-token', otp: '123456' })
+      ).rejects.toBe(errorObj);
+    });
+
     it('should call getEnrollmentFactors on the underlying spa-js mfa client', async () => {
       const mfaToken = 'test-mfa-token';
       mfaGetEnrollmentFactorsMock.mockResolvedValue([{ type: 'otp' }, { type: 'phone' }]);
@@ -204,6 +257,13 @@ describe('MFA', () => {
 
       expect(mfaGetEnrollmentFactorsMock).toHaveBeenCalledWith(mfaToken);
       expect(result).toEqual([{ type: 'otp' }, { type: 'phone' }]);
+    });
+
+    it('should bubble errors from getEnrollmentFactors to the caller', async () => {
+      const errorObj = new Error('getEnrollmentFactors failed');
+      mfaGetEnrollmentFactorsMock.mockRejectedValue(errorObj);
+
+      await expect(plugin.mfa.getEnrollmentFactors('test-mfa-token')).rejects.toBe(errorObj);
     });
   });
 });

--- a/__tests__/mfa.test.ts
+++ b/__tests__/mfa.test.ts
@@ -265,5 +265,21 @@ describe('MFA', () => {
 
       await expect(plugin.mfa.getEnrollmentFactors('test-mfa-token')).rejects.toBe(errorObj);
     });
+
+    it('should not set the plugin error ref or refresh reactive state when mfa.verify rejects', async () => {
+      mfaVerifyMock.mockRejectedValue(new Error('verify failed'));
+
+      // Clear calls accumulated during plugin.install (checkSession triggers __refreshState)
+      isAuthenticatedMock.mockClear();
+      getUserMock.mockClear();
+      getIdTokenClaimsMock.mockClear();
+
+      await plugin.mfa.verify({ mfaToken: 'test-mfa-token', otp: '000000' }).catch(() => {});
+
+      expect(plugin.error.value).toBeNull();
+      expect(isAuthenticatedMock).not.toHaveBeenCalled();
+      expect(getUserMock).not.toHaveBeenCalled();
+      expect(getIdTokenClaimsMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/__tests__/mfa.test.ts
+++ b/__tests__/mfa.test.ts
@@ -1,0 +1,209 @@
+import { App } from 'vue';
+import { createAuth0, useAuth0 } from '../src/index';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest
+} from '@jest/globals';
+import { inject } from 'vue';
+
+const mfaGetAuthenticatorsMock = jest.fn<any>().mockResolvedValue([]);
+const mfaEnrollMock = jest.fn<any>().mockResolvedValue({});
+const mfaChallengeMock = jest.fn<any>().mockResolvedValue({});
+const mfaVerifyMock = jest.fn<any>().mockResolvedValue({});
+const mfaGetEnrollmentFactorsMock = jest.fn<any>().mockResolvedValue([]);
+const checkSessionMock = jest.fn<any>().mockResolvedValue(null);
+const handleRedirectCallbackMock = jest.fn<any>().mockResolvedValue(null);
+const isAuthenticatedMock = jest.fn<any>().mockResolvedValue(false);
+const getUserMock = jest.fn<any>().mockResolvedValue(null);
+const getIdTokenClaimsMock = jest.fn<any>().mockResolvedValue(null);
+
+jest.mock('vue', () => {
+  const originalModule = jest.requireActual('vue');
+  return {
+    __esModule: true,
+    ...(originalModule as any),
+    inject: jest.fn()
+  };
+});
+
+jest.mock('@auth0/auth0-spa-js', () => {
+  return {
+    Auth0Client: jest.fn().mockImplementation(() => {
+      return {
+        checkSession: checkSessionMock,
+        handleRedirectCallback: handleRedirectCallbackMock,
+        loginWithRedirect: jest.fn<any>().mockResolvedValue(null),
+        loginWithPopup: jest.fn<any>().mockResolvedValue(null),
+        logout: jest.fn<any>(),
+        isAuthenticated: isAuthenticatedMock,
+        getUser: getUserMock,
+        getIdTokenClaims: getIdTokenClaimsMock,
+        getTokenSilently: jest.fn<any>().mockResolvedValue(null),
+        getTokenWithPopup: jest.fn<any>().mockResolvedValue(null),
+        getDpopNonce: jest.fn<any>().mockResolvedValue(undefined),
+        setDpopNonce: jest.fn<any>().mockResolvedValue(undefined),
+        generateDpopProof: jest.fn<any>().mockResolvedValue('mock-proof'),
+        createFetcher: jest.fn<any>().mockReturnValue({}),
+        mfa: {
+          setMFAAuthDetails: jest.fn(),
+          getAuthenticators: mfaGetAuthenticatorsMock,
+          enroll: mfaEnrollMock,
+          challenge: mfaChallengeMock,
+          verify: mfaVerifyMock,
+          getEnrollmentFactors: mfaGetEnrollmentFactorsMock
+        }
+      };
+    }),
+    MfaRequiredError: class MfaRequiredError extends Error {
+      mfa_token: string;
+      constructor(
+        error: string,
+        error_description: string,
+        mfa_token: string
+      ) {
+        super(error_description);
+        this.name = 'MfaRequiredError';
+        this.mfa_token = mfa_token;
+      }
+    },
+    MfaError: class MfaError extends Error {},
+    MfaListAuthenticatorsError: class MfaListAuthenticatorsError extends Error {},
+    MfaEnrollmentError: class MfaEnrollmentError extends Error {},
+    MfaChallengeError: class MfaChallengeError extends Error {},
+    MfaVerifyError: class MfaVerifyError extends Error {},
+    MfaEnrollmentFactorsError: class MfaEnrollmentFactorsError extends Error {}
+  };
+});
+
+describe('MFA', () => {
+  const savedLocation = window.location;
+  const savedHistory = window.history;
+  let appMock: App<any>;
+
+  beforeEach(() => {
+    delete (window as any).location;
+    window.location = Object.assign(new URL('https://example.org'), {
+      ancestorOrigins: '',
+      assign: jest.fn(),
+      reload: jest.fn(),
+      replace: jest.fn()
+    }) as any;
+
+    delete (window as any).history;
+    window.history = {
+      replaceState: jest.fn()
+    } as any;
+
+    isAuthenticatedMock.mockResolvedValue(false);
+    getUserMock.mockResolvedValue(null);
+    getIdTokenClaimsMock.mockResolvedValue(null);
+
+    appMock = {
+      config: {
+        globalProperties: {}
+      },
+      provide: jest.fn()
+    } as any as App<any>;
+
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: savedLocation,
+      writable: true,
+      configurable: true
+    });
+    window.history = savedHistory;
+  });
+
+  describe('useAuth0 mfa property', () => {
+    it('should expose the mfa client via useAuth0', () => {
+      const plugin = createAuth0({ domain: '', clientId: '' });
+      plugin.install(appMock);
+
+      (inject as jest.Mock).mockReturnValue(plugin);
+      const auth0 = useAuth0();
+
+      expect(auth0.mfa).toBeDefined();
+    });
+  });
+
+  describe('mfa methods', () => {
+    let plugin: ReturnType<typeof createAuth0>;
+
+    beforeEach(() => {
+      plugin = createAuth0({ domain: '', clientId: '' });
+      plugin.install(appMock);
+    });
+
+    it('should call getAuthenticators on the underlying spa-js mfa client', async () => {
+      const mfaToken = 'test-mfa-token';
+      mfaGetAuthenticatorsMock.mockResolvedValue([
+        { id: 'otp|dev_1', authenticatorType: 'otp', active: true }
+      ]);
+
+      const result = await plugin.mfa.getAuthenticators(mfaToken);
+
+      expect(mfaGetAuthenticatorsMock).toHaveBeenCalledWith(mfaToken);
+      expect(result).toEqual([
+        { id: 'otp|dev_1', authenticatorType: 'otp', active: true }
+      ]);
+    });
+
+    it('should call enroll on the underlying spa-js mfa client', async () => {
+      const enrollParams = { mfaToken: 'test-mfa-token', factorType: 'otp' as const };
+      const enrollResponse = {
+        authenticatorType: 'otp',
+        secret: 'BASE32SECRET',
+        barcodeUri: 'otpauth://totp/...'
+      };
+      mfaEnrollMock.mockResolvedValue(enrollResponse);
+
+      const result = await plugin.mfa.enroll(enrollParams);
+
+      expect(mfaEnrollMock).toHaveBeenCalledWith(enrollParams);
+      expect(result).toEqual(enrollResponse);
+    });
+
+    it('should call challenge on the underlying spa-js mfa client', async () => {
+      const challengeParams = {
+        mfaToken: 'test-mfa-token',
+        challengeType: 'otp' as const,
+        authenticatorId: 'otp|dev_1'
+      };
+      const challengeResponse = { challengeType: 'otp' as const };
+      mfaChallengeMock.mockResolvedValue(challengeResponse);
+
+      const result = await plugin.mfa.challenge(challengeParams);
+
+      expect(mfaChallengeMock).toHaveBeenCalledWith(challengeParams);
+      expect(result).toEqual(challengeResponse);
+    });
+
+    it('should call verify on the underlying spa-js mfa client', async () => {
+      const verifyParams = { mfaToken: 'test-mfa-token', otp: '123456' };
+      const tokenResponse = { access_token: 'new-access-token' };
+      mfaVerifyMock.mockResolvedValue(tokenResponse);
+
+      const result = await plugin.mfa.verify(verifyParams);
+
+      expect(mfaVerifyMock).toHaveBeenCalledWith(verifyParams);
+      expect(result).toEqual(tokenResponse);
+    });
+
+    it('should call getEnrollmentFactors on the underlying spa-js mfa client', async () => {
+      const mfaToken = 'test-mfa-token';
+      mfaGetEnrollmentFactorsMock.mockResolvedValue([{ type: 'otp' }, { type: 'phone' }]);
+
+      const result = await plugin.mfa.getEnrollmentFactors(mfaToken);
+
+      expect(mfaGetEnrollmentFactorsMock).toHaveBeenCalledWith(mfaToken);
+      expect(result).toEqual([{ type: 'otp' }, { type: 'phone' }]);
+    });
+  });
+});

--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -60,7 +60,15 @@ jest.mock('@auth0/auth0-spa-js', () => {
         getDpopNonce: getDpopNonceMock,
         setDpopNonce: setDpopNonceMock,
         generateDpopProof: generateDpopProofMock,
-        createFetcher: createFetcherMock
+        createFetcher: createFetcherMock,
+        mfa: {
+          setMFAAuthDetails: jest.fn(),
+          getAuthenticators: jest.fn<any>().mockResolvedValue([]),
+          enroll: jest.fn<any>().mockResolvedValue({}),
+          challenge: jest.fn<any>().mockResolvedValue({}),
+          verify: jest.fn<any>().mockResolvedValue({}),
+          getEnrollmentFactors: jest.fn<any>().mockResolvedValue([])
+        }
       };
     })
   };

--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -84,6 +84,16 @@ describe('Client', () => {
       `Please ensure Auth0's Vue plugin is correctly installed.`
     );
   });
+
+  it('logs console error when mfa methods are called before installing the plugin', async () => {
+    const spy = jest.spyOn(console, 'error');
+
+    await client.value.mfa.getAuthenticators('test-token');
+
+    expect(spy).toHaveBeenCalledWith(
+      `Please ensure Auth0's Vue plugin is correctly installed.`
+    );
+  });
 });
 
 describe('createAuth0', () => {

--- a/src/global.ts
+++ b/src/global.ts
@@ -6,11 +6,19 @@ export {
   User,
   InMemoryCache,
   LocalStorageCache,
-  UseDpopNonceError
+  UseDpopNonceError,
+  MfaRequiredError,
+  MfaError,
+  MfaListAuthenticatorsError,
+  MfaEnrollmentError,
+  MfaChallengeError,
+  MfaVerifyError,
+  MfaEnrollmentFactorsError
 } from '@auth0/auth0-spa-js';
 
 export type {
   AuthorizationParams,
+  InteractiveErrorHandler,
   PopupLoginOptions,
   PopupConfigOptions,
   GetTokenWithPopupOptions,
@@ -22,5 +30,24 @@ export type {
   Cacheable,
   FetcherConfig,
   Fetcher,
-  CustomFetchMinimalOutput
+  CustomFetchMinimalOutput,
+  MfaApiClient,
+  Authenticator,
+  AuthenticatorType,
+  OobChannel,
+  MfaFactorType,
+  EnrollParams,
+  EnrollOtpParams,
+  EnrollSmsParams,
+  EnrollVoiceParams,
+  EnrollEmailParams,
+  EnrollPushParams,
+  EnrollmentResponse,
+  OtpEnrollmentResponse,
+  OobEnrollmentResponse,
+  ChallengeAuthenticatorParams,
+  ChallengeResponse,
+  VerifyParams,
+  MfaGrantType,
+  EnrollmentFactor
 } from '@auth0/auth0-spa-js';

--- a/src/interfaces/auth0-vue-client.ts
+++ b/src/interfaces/auth0-vue-client.ts
@@ -11,7 +11,8 @@ import type {
   ConnectAccountRedirectResult,
   CustomFetchMinimalOutput,
   Fetcher,
-  FetcherConfig
+  FetcherConfig,
+  MfaApiClient
 } from '@auth0/auth0-spa-js';
 import type { Ref } from 'vue';
 import type { AppState } from './app-state';
@@ -266,4 +267,45 @@ export interface Auth0VueClient {
   createFetcher<TOutput extends CustomFetchMinimalOutput = Response>(
     config?: FetcherConfig<TOutput>
   ): Fetcher<TOutput>;
+
+  /**
+   * MFA API client for multi-factor authentication operations.
+   *
+   * Use this property to handle MFA challenge and enrollment flows
+   * after receiving a `MfaRequiredError` from `getAccessTokenSilently`.
+   *
+   * **Note:** `mfa.verify()` returns raw tokens but does not automatically
+   * update Vue's reactive state (`isAuthenticated`, `user`, `idTokenClaims`).
+   * Call `checkSession()` after a successful `verify()` to reflect the new
+   * session in your components.
+   *
+   * **Note:** Errors thrown by `mfa` methods are **not** captured in the
+   * `error` ref returned by `useAuth0()`. Unlike other SDK methods, MFA
+   * operations bypass the plugin's error handling proxy. Always wrap `mfa`
+   * calls in a `try/catch` and handle typed MFA errors (e.g.
+   * `MfaVerifyError`, `MfaChallengeError`) directly in your component.
+   *
+   * ```js
+   * import { MfaRequiredError } from '@auth0/auth0-vue';
+   *
+   * const { getAccessTokenSilently, mfa, checkSession } = useAuth0();
+   *
+   * try {
+   *   await getAccessTokenSilently();
+   * } catch (e) {
+   *   if (e instanceof MfaRequiredError) {
+   *     if (e.mfa_requirements?.enroll?.length) {
+   *       const factors = await mfa.getEnrollmentFactors(e.mfa_token);
+   *       // ... show enrollment UI
+   *     } else {
+   *       const authenticators = await mfa.getAuthenticators(e.mfa_token);
+   *       // ... show challenge UI, then:
+   *       await mfa.verify({ mfaToken: e.mfa_token, otp: userCode });
+   *       await checkSession(); // refresh isAuthenticated, user, etc.
+   *     }
+   *   }
+   * }
+   * ```
+   */
+  mfa: MfaApiClient;
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -22,7 +22,8 @@ import type {
   ConnectAccountRedirectResult,
   FetcherConfig,
   Fetcher,
-  CustomFetchMinimalOutput
+  CustomFetchMinimalOutput,
+  MfaApiClient
 } from '@auth0/auth0-spa-js';
 import { Auth0Client, User } from '@auth0/auth0-spa-js';
 import { bindPluginMethods, deprecateRedirectUri } from './utils';
@@ -54,7 +55,15 @@ const PLUGIN_NOT_INSTALLED_CLIENT: Auth0VueClient = {
   getDpopNonce: PLUGIN_NOT_INSTALLED_HANDLER,
   setDpopNonce: PLUGIN_NOT_INSTALLED_HANDLER,
   generateDpopProof: PLUGIN_NOT_INSTALLED_HANDLER,
-  createFetcher: PLUGIN_NOT_INSTALLED_HANDLER
+  createFetcher: PLUGIN_NOT_INSTALLED_HANDLER,
+  mfa: {
+    setMFAAuthDetails: PLUGIN_NOT_INSTALLED_HANDLER,
+    getAuthenticators: PLUGIN_NOT_INSTALLED_HANDLER,
+    enroll: PLUGIN_NOT_INSTALLED_HANDLER,
+    challenge: PLUGIN_NOT_INSTALLED_HANDLER,
+    verify: PLUGIN_NOT_INSTALLED_HANDLER,
+    getEnrollmentFactors: PLUGIN_NOT_INSTALLED_HANDLER
+  } as unknown as MfaApiClient
 };
 
 /**
@@ -75,6 +84,7 @@ export class Auth0Plugin implements Auth0VueClient {
   public user: Ref<User | undefined> = ref({});
   public idTokenClaims = ref<IdToken | undefined>();
   public error = ref<Error | null>(null);
+  public mfa: MfaApiClient = PLUGIN_NOT_INSTALLED_CLIENT.mfa;
 
   constructor(
     private clientOptions: Auth0VueClientOptions,
@@ -93,6 +103,8 @@ export class Auth0Plugin implements Auth0VueClient {
         version: version
       }
     });
+
+    this.mfa = this._client.mfa;
 
     this.__checkSession(app.config.globalProperties.$router);
 


### PR DESCRIPTION
## Summary

- Expose MFA operations via `Auth0VueClient.mfa` and `Auth0Plugin.mfa` (delegating to `Auth0Client.mfa`)
- Export MFA error classes and types from the public API
- Add unit tests for all MFA methods including error propagation
- Add MFA and Step-Up Authentication sections to `EXAMPLES.md`

## Test plan

- [x] Unit tests passing (`npm test`)
- [x] Manual: new user enroll flow (TOTP, SMS)
- [x] Manual: existing user challenge flow (OTP)
- [x] Manual: existing user challenge flow (Email / OOB)
- [x] Manual: recovery code fallback
- [x] Manual: step-up auth via `interactiveErrorHandler: 'popup'`

## Notes

- `verify()` does not update Vue reactive state (`isAuthenticated`, `user`). Callers should follow up with `getAccessTokenSilently()` to reflect the new session in the UI. This is documented in the `verify()` JSDoc and `EXAMPLES.md`.
- MFA is currently in Early Access, noted in `EXAMPLES.md`.
