### PR TITLE
fix: pin npm to 11.10.0 to fix CI failure

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -26,7 +26,7 @@ runs:
 
     - name: Update npm to version 11
       shell: bash
-      run: npm install -g npm@11
+      run: npm install -g npm@11.10.0
 
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
## Summary

- Pins npm to `11.10.0` instead of the generic `npm@11`
- npm 11.12.0 removed `promise-retry` from its bundle, causing `npm install -g npm@11` to fail on Node 22.22.2 mid-upgrade
- Workaround until upstream fix lands in [npm/cli#9152](https://github.com/npm/cli/issues/9152)