### PR TITLE
chore: add setup-node-npm composite action and centralize Node setup

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -11,11 +11,10 @@ runs:
   using: composite
 
   steps:
-    - name: Setup Node
-      uses: actions/setup-node@v3
+    - name: Setup Node and npm
+      uses: ./.github/actions/setup-node-npm
       with:
         node-version: ${{ inputs.node }}
-        cache: 'npm'
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -17,16 +17,11 @@ runs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Setup Node
-      uses: actions/setup-node@v4
+    - name: Setup Node and npm
+      uses: ./.github/actions/setup-node-npm
       with:
         node-version: ${{ inputs.node-version }}
-        cache: 'npm'
         registry-url: 'https://registry.npmjs.org'
-
-    - name: Update npm to version 11
-      shell: bash
-      run: npm install -g npm@11.10.0
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/setup-node-npm/action.yml
+++ b/.github/actions/setup-node-npm/action.yml
@@ -1,0 +1,30 @@
+name: Setup Node and npm
+description: Setup Node.js and upgrade npm to version 11 for trusted publishing support
+
+inputs:
+  node-version:
+    description: The Node version to use
+    required: false
+    default: '22'
+  cache:
+    description: Package manager for caching. Supported values: npm, yarn, pnpm. Set to empty string to disable.
+    required: false
+    default: 'npm'
+  registry-url:
+    description: Registry URL for publishing
+    required: false
+
+runs:
+  using: composite
+
+  steps:
+    - name: Setup Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: ${{ inputs.cache }}
+        registry-url: ${{ inputs.registry-url }}
+
+    - name: Update npm to version 11
+      shell: bash
+      run: npm install -g npm@11.10.0

--- a/.github/actions/setup-node-npm/action.yml
+++ b/.github/actions/setup-node-npm/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: '22'
   cache:
-    description: Package manager for caching. Supported values: npm, yarn, pnpm. Set to empty string to disable.
+    description: 'Package manager for caching. Supported values: npm, yarn, pnpm. Set to empty string to disable.'
     required: false
     default: 'npm'
   registry-url:


### PR DESCRIPTION
## Summary

- Adds `.github/actions/setup-node-npm` composite action that wraps `setup-node@v6` and upgrades npm to v11.10.0, consistent with the pattern in auth0-angular
- Updates `build` action from `setup-node@v3` → composite action
- Updates `npm-publish` action from `setup-node@v4` + inline npm upgrade → composite action
- Preserves `registry-url` in `npm-publish` for authentication