### PR TITLE
chore: simplify setup-node-npm and use it consistently across CI

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -21,7 +21,6 @@ runs:
       uses: ./.github/actions/setup-node-npm
       with:
         node-version: ${{ inputs.node-version }}
-        registry-url: 'https://registry.npmjs.org'
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/setup-node-npm/action.yml
+++ b/.github/actions/setup-node-npm/action.yml
@@ -6,13 +6,6 @@ inputs:
     description: The Node version to use
     required: false
     default: '22'
-  cache:
-    description: 'Package manager for caching. Supported values: npm, yarn, pnpm. Set to empty string to disable.'
-    required: false
-    default: 'npm'
-  registry-url:
-    description: Registry URL for publishing
-    required: false
 
 runs:
   using: composite
@@ -22,8 +15,6 @@ runs:
       uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
-        cache: ${{ inputs.cache }}
-        registry-url: ${{ inputs.registry-url }}
 
     - name: Update npm to version 11
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,11 +51,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Node
-        uses: actions/setup-node@v6
+      - name: Setup Node and npm
+        uses: ./.github/actions/setup-node-npm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: npm
 
       - name: Restore build artifacts
         uses: actions/cache/restore@v5
@@ -79,11 +78,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Node
-        uses: actions/setup-node@v6
+      - name: Setup Node and npm
+        uses: ./.github/actions/setup-node-npm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: npm
 
       - name: Restore build artifacts
         uses: actions/cache/restore@v5
@@ -104,11 +102,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Node
-        uses: actions/setup-node@v6
+      - name: Setup Node and npm
+        uses: ./.github/actions/setup-node-npm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: npm
 
       - name: Restore build artifacts
         uses: actions/cache/restore@v5


### PR DESCRIPTION
## Summary

- Simplifies `setup-node-npm` to only accept `node-version`, removing unused `cache` and `registry-url` inputs — aligns with auth0-angular
- Removes `registry-url` from `npm-publish` action call to `setup-node-npm`
- Replaces direct `actions/setup-node@v6` calls in `test.yml` with `setup-node-npm` so all CI jobs use a consistent Node and npm version