### PR TITLE
feat: add custom token exchange support

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -13,6 +13,7 @@
 - [Device-bound tokens with DPoP](#device-bound-tokens-with-dpop)
 - [Multi-Factor Authentication (MFA)](#multi-factor-authentication-mfa)
 - [Step-Up Authentication](#step-up-authentication)
+- [Custom Token Exchange](#custom-token-exchange)
 
 ## Add login to your application
 
@@ -1552,3 +1553,64 @@ With `interactiveErrorHandler: 'popup'` set, no special error handling is needed
 
 If there is a problem with the popup, `getAccessTokenSilently` will throw one of `PopupOpenError`, `PopupCancelledError`, or `PopupTimeoutError`.
 
+## Custom Token Exchange
+
+Exchange an external token for Auth0 tokens using the Custom Token Exchange grant ([RFC 8693](https://www.rfc-editor.org/rfc/rfc8693)). This establishes a full Auth0 session — after a successful exchange, `isAuthenticated` will be `true` and `user` will be populated.
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { loginWithCustomTokenExchange, isAuthenticated, user } = useAuth0();
+
+      const exchangeToken = async (externalToken) => {
+        try {
+          await loginWithCustomTokenExchange({
+            subject_token: externalToken,
+            subject_token_type: 'urn:your-company:legacy-system-token',
+            audience: 'https://api.example.com/',
+            scope: 'openid profile email'
+          });
+        } catch (e) {
+          console.error('Token exchange failed:', e);
+        }
+      };
+
+      return { exchangeToken, isAuthenticated, user };
+    }
+  };
+</script>
+```
+
+<details>
+  <summary>Using Options API</summary>
+
+```html
+<script>
+  export default {
+    methods: {
+      async exchangeToken(externalToken) {
+        try {
+          await this.$auth0.loginWithCustomTokenExchange({
+            subject_token: externalToken,
+            subject_token_type: 'urn:your-company:legacy-system-token',
+            audience: 'https://api.example.com/',
+            scope: 'openid profile email'
+          });
+        } catch (e) {
+          console.error('Token exchange failed:', e);
+        }
+      }
+    }
+  };
+</script>
+```
+
+</details>
+
+**Notes:**
+- `subject_token_type` must be a namespaced URI under your organization's control. Well-known prefixes such as `urn:ietf:params:oauth:*`, `urn:auth0:*`, and `https://auth0.com/*` are reserved and should not be used for custom token types. See the [Auth0 Custom Token Exchange documentation](https://auth0.com/docs/authenticate/login/custom-token-exchange) for details.
+- The external token must be validated in an Auth0 Action using strong cryptographic verification.
+- `audience` and `scope` fall back to the SDK's configured defaults if not provided.

--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -145,6 +145,10 @@ describe('Auth0Plugin', () => {
     getIdTokenClaimsMock.mockResolvedValue(null);
     loginWithRedirectMock.mockResolvedValue(null);
     loginWithPopupMock.mockResolvedValue(null);
+    loginWithCustomTokenExchangeMock.mockResolvedValue({
+      access_token: '__test_access_token__',
+      token_type: 'Bearer'
+    });
     checkSessionMock.mockResolvedValue(null);
 
     appMock = {

--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -28,6 +28,10 @@ const getTokenWithPopupMock = jest.fn<any>().mockResolvedValue(null);
 const getDpopNonceMock = jest.fn<any>().mockResolvedValue(undefined);
 const setDpopNonceMock = jest.fn<any>().mockResolvedValue(undefined);
 const generateDpopProofMock = jest.fn<any>().mockResolvedValue('mock-proof');
+const loginWithCustomTokenExchangeMock = jest.fn<any>().mockResolvedValue({
+  access_token: '__test_access_token__',
+  token_type: 'Bearer'
+});
 const createFetcherMock = jest.fn<any>().mockReturnValue({
   fetchWithAuth: jest.fn<any>().mockResolvedValue({ status: 200, data: 'test' })
 });
@@ -60,6 +64,7 @@ jest.mock('@auth0/auth0-spa-js', () => {
         getDpopNonce: getDpopNonceMock,
         setDpopNonce: setDpopNonceMock,
         generateDpopProof: generateDpopProofMock,
+        loginWithCustomTokenExchange: loginWithCustomTokenExchangeMock,
         createFetcher: createFetcherMock,
         mfa: {
           setMFAAuthDetails: jest.fn(),
@@ -1358,6 +1363,116 @@ describe('Auth0Plugin', () => {
     getDpopNonceMock.mockResolvedValue('nonce-123');
 
     await appMock.config.globalProperties.$auth0.getDpopNonce('my-api');
+
+    expect(appMock.config.globalProperties.$auth0.error.value).toBeFalsy();
+  });
+
+  it('should proxy loginWithCustomTokenExchange', async () => {
+    const plugin = createAuth0({
+      domain: '',
+      clientId: ''
+    });
+
+    plugin.install(appMock);
+
+    const options = {
+      subject_token: '__test_subject_token__',
+      subject_token_type: 'urn:acme:legacy-system-token',
+      scope: 'openid profile email'
+    };
+
+    const result =
+      await appMock.config.globalProperties.$auth0.loginWithCustomTokenExchange(
+        options
+      );
+
+    expect(loginWithCustomTokenExchangeMock).toHaveBeenCalledWith(options);
+    expect(result).toEqual({
+      access_token: '__test_access_token__',
+      token_type: 'Bearer'
+    });
+  });
+
+  it('should update auth state after loginWithCustomTokenExchange', async () => {
+    const plugin = createAuth0({
+      domain: '',
+      clientId: ''
+    });
+
+    plugin.install(appMock);
+
+    isAuthenticatedMock.mockResolvedValue(true);
+    getUserMock.mockResolvedValue({ name: '__test_user__' });
+
+    await appMock.config.globalProperties.$auth0.loginWithCustomTokenExchange({
+      subject_token: '__test_subject_token__',
+      subject_token_type: 'urn:acme:legacy-system-token'
+    });
+
+    expect(
+      appMock.config.globalProperties.$auth0.isAuthenticated.value
+    ).toEqual(true);
+    expect(appMock.config.globalProperties.$auth0.user.value).toEqual({
+      name: '__test_user__'
+    });
+  });
+
+  it('should track errors when loginWithCustomTokenExchange throws', async () => {
+    const plugin = createAuth0({
+      domain: '',
+      clientId: ''
+    });
+
+    plugin.install(appMock);
+
+    loginWithCustomTokenExchangeMock.mockRejectedValue('Some Error');
+
+    try {
+      await appMock.config.globalProperties.$auth0.loginWithCustomTokenExchange(
+        {
+          subject_token: '__test_subject_token__',
+          subject_token_type: 'urn:acme:legacy-system-token'
+        }
+      );
+    } catch (e) {}
+
+    expect(appMock.config.globalProperties.$auth0.error.value).toEqual(
+      'Some Error'
+    );
+  });
+
+  it('should clear errors when loginWithCustomTokenExchange is successful', async () => {
+    const plugin = createAuth0({
+      domain: '',
+      clientId: ''
+    });
+
+    plugin.install(appMock);
+
+    loginWithCustomTokenExchangeMock.mockRejectedValue('Some Error');
+
+    try {
+      await appMock.config.globalProperties.$auth0.loginWithCustomTokenExchange(
+        {
+          subject_token: '__test_subject_token__',
+          subject_token_type: 'urn:acme:legacy-system-token'
+        }
+      );
+    } catch (e) {}
+
+    expect(appMock.config.globalProperties.$auth0.error.value).toEqual(
+      'Some Error'
+    );
+
+    loginWithCustomTokenExchangeMock.mockResolvedValue({
+      access_token: '__test_access_token__',
+      token_type: 'Bearer'
+    });
+
+    await appMock.config.globalProperties.$auth0.loginWithCustomTokenExchange({
+      subject_token: '__test_subject_token__',
+      subject_token_type: 'urn:acme:legacy-system-token'
+    });
 
     expect(appMock.config.globalProperties.$auth0.error.value).toBeFalsy();
   });

--- a/src/global.ts
+++ b/src/global.ts
@@ -19,6 +19,8 @@ export {
 export type {
   AuthorizationParams,
   InteractiveErrorHandler,
+  CustomTokenExchangeOptions,
+  TokenEndpointResponse,
   PopupLoginOptions,
   PopupConfigOptions,
   GetTokenWithPopupOptions,

--- a/src/interfaces/auth0-vue-client.ts
+++ b/src/interfaces/auth0-vue-client.ts
@@ -12,7 +12,9 @@ import type {
   CustomFetchMinimalOutput,
   Fetcher,
   FetcherConfig,
-  MfaApiClient
+  MfaApiClient,
+  CustomTokenExchangeOptions,
+  TokenEndpointResponse
 } from '@auth0/auth0-spa-js';
 import type { Ref } from 'vue';
 import type { AppState } from './app-state';
@@ -87,6 +89,29 @@ export interface Auth0VueClient {
    * @param options
    */
   loginWithRedirect(options?: RedirectLoginOptions<AppState>): Promise<void>;
+
+  /**
+   * ```js
+   * const tokenResponse = await loginWithCustomTokenExchange({
+   *   subject_token: 'external_token_value',
+   *   subject_token_type: 'urn:acme:legacy-system-token',
+   *   scope: 'openid profile email'
+   * });
+   * ```
+   *
+   * Exchanges an external subject token for Auth0 tokens and logs the user in.
+   * This method implements the Custom Token Exchange grant as specified in RFC 8693.
+   *
+   * The exchanged tokens are automatically cached, establishing an authenticated session.
+   * After calling this method, `isAuthenticated` will be `true` and `user` will contain
+   * the user's information.
+   *
+   * @param options - The options required to perform the token exchange
+   * @returns A promise that resolves to the token endpoint response containing Auth0 tokens
+   */
+  loginWithCustomTokenExchange(
+    options: CustomTokenExchangeOptions
+  ): Promise<TokenEndpointResponse>;
 
   /**
    * After the browser redirects back to the callback page,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -23,7 +23,9 @@ import type {
   FetcherConfig,
   Fetcher,
   CustomFetchMinimalOutput,
-  MfaApiClient
+  MfaApiClient,
+  CustomTokenExchangeOptions,
+  TokenEndpointResponse
 } from '@auth0/auth0-spa-js';
 import { Auth0Client, User } from '@auth0/auth0-spa-js';
 import { bindPluginMethods, deprecateRedirectUri } from './utils';
@@ -47,6 +49,7 @@ const PLUGIN_NOT_INSTALLED_CLIENT: Auth0VueClient = {
   error: ref(null),
   loginWithPopup: PLUGIN_NOT_INSTALLED_HANDLER,
   loginWithRedirect: PLUGIN_NOT_INSTALLED_HANDLER,
+  loginWithCustomTokenExchange: PLUGIN_NOT_INSTALLED_HANDLER,
   getAccessTokenSilently: PLUGIN_NOT_INSTALLED_HANDLER,
   getAccessTokenWithPopup: PLUGIN_NOT_INSTALLED_HANDLER,
   logout: PLUGIN_NOT_INSTALLED_HANDLER,
@@ -158,6 +161,14 @@ export class Auth0Plugin implements Auth0VueClient {
   ) {
     deprecateRedirectUri(options);
     return this.__proxy(() => this._client.getTokenWithPopup(options, config));
+  }
+
+  async loginWithCustomTokenExchange(
+    options: CustomTokenExchangeOptions
+  ): Promise<TokenEndpointResponse> {
+    return this.__proxy(() =>
+      this._client.loginWithCustomTokenExchange(options)
+    );
   }
 
   async checkSession(options?: GetTokenSilentlyOptions) {


### PR DESCRIPTION
## Summary

- Adds `loginWithCustomTokenExchange()` so apps can swap an external token for Auth0 tokens
- After a successful exchange, the user is logged in and `isAuthenticated`/`user` update automatically
- New types `CustomTokenExchangeOptions` and `TokenEndpointResponse` are now exported for app use
- Added usage examples in `EXAMPLES.md` for both Composition API and Options API

## Test plan

- [x] 4 new unit tests added (proxy call, state update, error on failure, error clears on retry)
- [x] All 61 tests pass
- [x] `plugin.ts` at 100% coverage
- [x] TypeScript compiles without errors
- [x] Manually tested against a live Auth0 tenant, confirmed `isAuthenticated` and `user` populate correctly after exchange