### PR TITLE
fix: respect appState.target when no router is present

### DIFF
--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -545,13 +545,18 @@ describe('Auth0Plugin', () => {
     });
   });
 
-  it('should preserve pathname when calling replaceState for subdirectory deployments', async () => {
+  it('should preserve pathname when calling replaceState for subdirectory deployments with router', async () => {
+    const routerPushMock = jest.fn();
     const plugin = createAuth0({
       domain: '',
       clientId: ''
     });
 
-    // Simulate subdirectory deployment
+    appMock.config.globalProperties['$router'] = {
+      push: routerPushMock
+    } as unknown as Router;
+
+    // Simulate subdirectory deployment with router
     delete (window as any).location;
     const mockLocation = {
       href: 'https://example.org/subdir?code=123&state=xyz',
@@ -572,6 +577,83 @@ describe('Auth0Plugin', () => {
 
     handleRedirectCallbackMock.mockResolvedValue({
       appState: { target: '/dashboard' }
+    });
+
+    plugin.install(appMock);
+
+    expect.assertions(2);
+
+    return flushPromises().then(() => {
+      expect(replaceStateMock).toHaveBeenCalledWith({}, '', '/subdir');
+      expect(routerPushMock).toHaveBeenCalledWith('/dashboard');
+    });
+  });
+
+  it('should use appState.target for replaceState when no router is present', async () => {
+    const plugin = createAuth0({
+      domain: '',
+      clientId: ''
+    });
+
+    // Simulate subdirectory deployment with no router
+    delete (window as any).location;
+    const mockLocation = {
+      href: 'https://example.org/subdir?code=123&state=xyz',
+      origin: 'https://example.org',
+      protocol: 'https:',
+      host: 'example.org',
+      hostname: 'example.org',
+      port: '',
+      pathname: '/subdir',
+      search: '?code=123&state=xyz',
+      hash: '',
+      ancestorOrigins: '',
+      assign: jest.fn(),
+      reload: jest.fn(),
+      replace: jest.fn()
+    };
+    window.location = mockLocation as any;
+
+    handleRedirectCallbackMock.mockResolvedValue({
+      appState: { target: '/dashboard' }
+    });
+
+    plugin.install(appMock);
+
+    expect.assertions(1);
+
+    return flushPromises().then(() => {
+      expect(replaceStateMock).toHaveBeenCalledWith({}, '', '/dashboard');
+    });
+  });
+
+  it('should preserve pathname for replaceState in subdirectory deployment when no router and no appState.target', async () => {
+    const plugin = createAuth0({
+      domain: '',
+      clientId: ''
+    });
+
+    // Simulate subdirectory deployment with no router and no appState.target
+    delete (window as any).location;
+    const mockLocation = {
+      href: 'https://example.org/subdir?code=123&state=xyz',
+      origin: 'https://example.org',
+      protocol: 'https:',
+      host: 'example.org',
+      hostname: 'example.org',
+      port: '',
+      pathname: '/subdir',
+      search: '?code=123&state=xyz',
+      hash: '',
+      ancestorOrigins: '',
+      assign: jest.fn(),
+      reload: jest.fn(),
+      replace: jest.fn()
+    };
+    window.location = mockLocation as any;
+
+    handleRedirectCallbackMock.mockResolvedValue({
+      appState: {}
     });
 
     plugin.install(appMock);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -219,13 +219,18 @@ export class Auth0Plugin implements Auth0VueClient {
       ) {
         const result = await this.handleRedirectCallback();
         const appState = result?.appState;
-        const target = appState?.target ?? '/';
-
-        // Remove query parameters from the URL, keeping the exact pathname.
-        window.history.replaceState({}, '', window.location.pathname);
+        const appStateTarget = appState?.target;
+        const target = appStateTarget ?? '/';
 
         if (router) {
+          window.history.replaceState({}, '', window.location.pathname);
           router.push(target);
+        } else {
+          window.history.replaceState(
+            {},
+            '',
+            appStateTarget ?? window.location.pathname
+          );
         }
 
         return result;


### PR DESCRIPTION
## Summary

When `vue-router` is not used, the SDK was not navigating to `appState.target` after the redirect callback. It was only cleaning up the URL back to the current pathname, so `appState.target` had no effect.

Changes:
- With router: behaviour unchanged. `replaceState` cleans up the URL, then `router.push` navigates to the target.
- Without router: `replaceState` now navigates to `appState.target` when set. Falls back to `window.location.pathname` when not set, so subdirectory deployments are not broken.

Closes #414

## Test plan

- [x] No router + `appState.target` set -> navigates to target
- [x] No router + no `appState.target` + subdirectory -> stays at current pathname
- [x] Router + subdirectory -> `replaceState` preserves pathname, `router.push` navigates to target