### PR TITLE
fix: convert typedoc config to ESM

### DIFF
--- a/typedoc.js
+++ b/typedoc.js
@@ -1,6 +1,6 @@
 const excludeFiles = [];
 
-module.exports = {
+export default {
   entryPoints: ['./src/index.ts'], // Changed from: includes: './src'
   out: './docs/',
   readme: './README.MD',


### PR DESCRIPTION
`typedoc.js` was broken after `"type": "module"` was added to `package.json` in #472, causing `npm run docs` to fail with a parse error.

Converts `module.exports` to `export default` so the config is treated as valid ESM.