### PR TITLE
feat: add Passkeys and MyAccount API support

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1664,11 +1664,13 @@ app.use(
 );
 ```
 
-You must also enable **Refresh Token Rotation** in your Auth0 Dashboard under **Applications** > your app > **Settings** > **Refresh Token Rotation**.
+It is also recommended to enable **Refresh Token Rotation** in your Auth0 Dashboard under **Applications** > your app > **Settings** > **Refresh Token Rotation**.
 
 ### Signup with Passkey
 
 Register a new user with a passkey. The SDK handles the entire flow internally — requesting a challenge from Auth0, triggering the browser's WebAuthn credential creation ceremony, and exchanging the credential for tokens. After a successful call, `isAuthenticated`, `user`, and `getAccessTokenSilently()` all work as expected.
+
+At least one user identifier (`email`, `phoneNumber`, or `username`) is required. Which identifiers are accepted depends on what is configured on your database connection.
 
 ```html
 <script>
@@ -1680,8 +1682,7 @@ Register a new user with a passkey. The SDK handles the entire flow internally �
 
       const signupWithPasskey = async () => {
         await passkey.signup({
-          email: 'user@example.com',
-          name: 'Jane Doe' // optional display name
+          email: 'user@example.com' // required — at least one of: email, phoneNumber, username
         });
       };
 
@@ -1691,7 +1692,7 @@ Register a new user with a passkey. The SDK handles the entire flow internally �
 </script>
 ```
 
-You can also pass `scope` and `audience` to control the access token:
+All supported options:
 
 ```html
 <script>
@@ -1703,7 +1704,24 @@ You can also pass `scope` and `audience` to control the access token:
 
       const signupWithPasskey = async () => {
         await passkey.signup({
+          // Identifiers — at least one required
           email: 'user@example.com',
+          phoneNumber: '+15551234567', // E.164 format
+          username: 'janedoe',
+
+          // Profile fields — all optional
+          name: 'Jane Doe',           // display name
+          givenName: 'Jane',
+          familyName: 'Doe',
+          nickname: 'janie',
+          picture: 'https://example.com/avatar.png',
+          userMetadata: { plan: 'pro' }, // stored in user_metadata on the Auth0 user
+
+          // Context — optional
+          realm: 'Username-Password-Authentication', // database connection name
+          organization: 'org_abc123',
+
+          // Token control — optional
           scope: 'openid profile email read:products',
           audience: 'https://api.example.com'
         });
@@ -1876,6 +1894,37 @@ Both `signup()` and `login()` throw typed errors for precise error handling:
 </script>
 ```
 
+If your tenant requires MFA after a passkey login, `passkey.login()` will throw an `MfaRequiredError`. Handle it using the MFA API:
+
+```html
+<script>
+  import { useAuth0, PasskeyError, MfaRequiredError } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { passkey, mfa } = useAuth0();
+
+      const loginWithPasskey = async () => {
+        try {
+          await passkey.login();
+        } catch (error) {
+          if (error instanceof MfaRequiredError) {
+            // MFA step-up required — proceed with the MFA API
+            const mfaToken = error.mfa_token;
+            const authenticators = await mfa.getAuthenticators(mfaToken);
+            // continue with challenge/verify flow — see the MFA section for full examples
+          } else if (error instanceof PasskeyError) {
+            console.error('Login failed:', error.message);
+          }
+        }
+      };
+
+      return { loginWithPasskey };
+    }
+  };
+</script>
+```
+
 > **Tip:** Both `signup()` and `login()` throw an error if the user cancels the biometric prompt. Wrap calls in `try/catch` to handle cancellation, network failures, or misconfigured connections.
 
 ## MyAccount API
@@ -1984,7 +2033,7 @@ Get the list of MFA factors and their enabled status for the current user.
 
 #### Update an authentication method
 
-Currently supported for passkey methods — for example, to rename a passkey:
+Rename a `totp` or `push-notification` method using the `name` field. For `phone` methods, update the preferred delivery channel using `preferred_authentication_method`.
 
 ```html
 <script>
@@ -1994,14 +2043,23 @@ Currently supported for passkey methods — for example, to rename a passkey:
     setup() {
       const { myAccount } = useAuth0();
 
-      const renamePasskey = async (methodId) => {
+      // Rename a totp or push-notification method
+      const renameMethod = async (methodId) => {
         const updated = await myAccount.updateAuthenticationMethod(methodId, {
-          name: 'My Work Laptop'
+          name: 'My Authenticator App'
         });
         console.log(updated);
       };
 
-      return { renamePasskey };
+      // Update preferred delivery channel for a phone method
+      const updatePhoneMethod = async (methodId) => {
+        const updated = await myAccount.updateAuthenticationMethod(methodId, {
+          preferred_authentication_method: 'voice' // 'sms' | 'voice'
+        });
+        console.log(updated);
+      };
+
+      return { renameMethod, updatePhoneMethod };
     }
   };
 </script>

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -14,6 +14,8 @@
 - [Multi-Factor Authentication (MFA)](#multi-factor-authentication-mfa)
 - [Step-Up Authentication](#step-up-authentication)
 - [Custom Token Exchange](#custom-token-exchange)
+- [Passkeys](#passkeys)
+- [MyAccount API](#myaccount-api)
 
 ## Add login to your application
 
@@ -1614,3 +1616,634 @@ Exchange an external token for Auth0 tokens using the Custom Token Exchange gran
 - `subject_token_type` must be a namespaced URI under your organization's control. Well-known prefixes such as `urn:ietf:params:oauth:*`, `urn:auth0:*`, and `https://auth0.com/*` are reserved and should not be used for custom token types. See the [Auth0 Custom Token Exchange documentation](https://auth0.com/docs/authenticate/login/custom-token-exchange) for details.
 - The external token must be validated in an Auth0 Action using strong cryptographic verification.
 - `audience` and `scope` fall back to the SDK's configured defaults if not provided.
+
+## Passkeys
+
+Passkeys provide password-less authentication using platform biometrics (Face ID, Touch ID, Windows Hello) or security keys via the WebAuthn standard. The SDK supports two flows:
+
+- **Signup**: Register a new user with a passkey
+- **Login**: Authenticate an existing user with a passkey
+
+- [Setup](#setup-1)
+- [Important: Use Refresh Tokens with Passkeys](#important-use-refresh-tokens-with-passkeys)
+- [Signup with Passkey](#signup-with-passkey)
+- [Login with Passkey](#login-with-passkey)
+- [Complete Passkey Flow Example](#complete-passkey-flow-example)
+- [Passkey Error Handling](#passkey-error-handling)
+
+### Setup
+
+Before using passkeys, ensure the following are configured in your [Auth0 Dashboard](https://manage.auth0.com):
+
+1. **Enable passkey authentication method**: Go to **Authentication** > **Database** > your connection > **Authentication Methods** > **Passkey**.
+2. **Enable the WebAuthn passkey grant**: Go to your **Application** > **Advanced Settings** > **Grant Types** and enable the **Passkey** grant.
+3. **Custom domain required**: Passkeys are bound to an origin (domain). A [custom domain](https://auth0.com/docs/customize/custom-domains) must be configured — passkeys will not work on the default `*.auth0.com` domain.
+
+### Important: Use Refresh Tokens with Passkeys
+
+> **Important:** When using passkeys, you **must** configure `createAuth0` with `useRefreshTokens: true`.
+
+Passkey authentication uses a direct token exchange (`/oauth/token` with the WebAuthn grant type) and does **not** create an Auth0 session cookie. Without refresh tokens, `getAccessTokenSilently()` will fail with `login_required` when the access token expires — or worse, silently return tokens for a different user if a prior redirect-based session cookie exists.
+
+```js
+// main.js
+import { createApp } from 'vue';
+import { createAuth0 } from '@auth0/auth0-vue';
+
+const app = createApp(App);
+
+app.use(
+  createAuth0({
+    domain: 'YOUR_AUTH0_DOMAIN',
+    clientId: 'YOUR_AUTH0_CLIENT_ID',
+    useRefreshTokens: true, // Required for passkey-based sessions
+    authorizationParams: {
+      redirect_uri: window.location.origin
+    }
+  })
+);
+```
+
+You must also enable **Refresh Token Rotation** in your Auth0 Dashboard under **Applications** > your app > **Settings** > **Refresh Token Rotation**.
+
+### Signup with Passkey
+
+Register a new user with a passkey. The SDK handles the entire flow internally — requesting a challenge from Auth0, triggering the browser's WebAuthn credential creation ceremony, and exchanging the credential for tokens. After a successful call, `isAuthenticated`, `user`, and `getAccessTokenSilently()` all work as expected.
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { passkey } = useAuth0();
+
+      const signupWithPasskey = async () => {
+        await passkey.signup({
+          email: 'user@example.com',
+          name: 'Jane Doe' // optional display name
+        });
+      };
+
+      return { signupWithPasskey };
+    }
+  };
+</script>
+```
+
+You can also pass `scope` and `audience` to control the access token:
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { passkey } = useAuth0();
+
+      const signupWithPasskey = async () => {
+        await passkey.signup({
+          email: 'user@example.com',
+          scope: 'openid profile email read:products',
+          audience: 'https://api.example.com'
+        });
+      };
+
+      return { signupWithPasskey };
+    }
+  };
+</script>
+```
+
+### Login with Passkey
+
+Authenticate an existing user with their registered passkey. A single call handles the entire assertion flow.
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { passkey } = useAuth0();
+
+      const loginWithPasskey = async () => {
+        await passkey.login();
+        // Or with optional params:
+        // await passkey.login({ realm, organization, scope, audience });
+      };
+
+      return { loginWithPasskey };
+    }
+  };
+</script>
+```
+
+### Complete Passkey Flow Example
+
+```html
+<template>
+  <div v-if="isAuthenticated">
+    <p>Welcome, {{ user.name }}!</p>
+  </div>
+  <div v-else>
+    <button @click="handleSignup">Sign up with Passkey</button>
+    <button @click="handleLogin">Sign in with Passkey</button>
+    <p v-if="errorMessage" class="error">{{ errorMessage }}</p>
+  </div>
+</template>
+
+<script>
+  import { ref } from 'vue';
+  import { useAuth0, PasskeyError, PasskeyRegisterError } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { passkey, isAuthenticated, user } = useAuth0();
+      const errorMessage = ref('');
+
+      const handleSignup = async () => {
+        try {
+          await passkey.signup({ email: 'user@example.com' });
+          // isAuthenticated and user are now updated automatically
+        } catch (error) {
+          if (error instanceof PasskeyRegisterError) {
+            errorMessage.value = `Registration failed: ${error.message}`;
+          } else if (error instanceof PasskeyError) {
+            errorMessage.value = `Passkey error: ${error.message}`;
+          }
+        }
+      };
+
+      const handleLogin = async () => {
+        try {
+          await passkey.login();
+          // isAuthenticated and user are now updated automatically
+        } catch (error) {
+          if (error instanceof PasskeyError) {
+            errorMessage.value = `Passkey error: ${error.message}`;
+          }
+        }
+      };
+
+      return { isAuthenticated, user, errorMessage, handleSignup, handleLogin };
+    }
+  };
+</script>
+```
+
+<details>
+  <summary>Using Options API</summary>
+
+```html
+<script>
+  import { PasskeyError, PasskeyRegisterError } from '@auth0/auth0-vue';
+
+  export default {
+    data() {
+      return { errorMessage: '' };
+    },
+    methods: {
+      async handleSignup() {
+        try {
+          await this.$auth0.passkey.signup({ email: 'user@example.com' });
+        } catch (error) {
+          if (error instanceof PasskeyRegisterError) {
+            this.errorMessage = `Registration failed: ${error.message}`;
+          } else if (error instanceof PasskeyError) {
+            this.errorMessage = `Passkey error: ${error.message}`;
+          }
+        }
+      },
+      async handleLogin() {
+        try {
+          await this.$auth0.passkey.login();
+        } catch (error) {
+          if (error instanceof PasskeyError) {
+            this.errorMessage = `Passkey error: ${error.message}`;
+          }
+        }
+      }
+    }
+  };
+</script>
+```
+
+</details>
+
+### Passkey Error Handling
+
+Both `signup()` and `login()` throw typed errors for precise error handling:
+
+```html
+<script>
+  import { useAuth0, PasskeyError, PasskeyRegisterError, PasskeyChallengeError } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { passkey } = useAuth0();
+
+      const signupWithPasskey = async () => {
+        try {
+          await passkey.signup({ email: 'user@example.com' });
+        } catch (error) {
+          if (error instanceof PasskeyRegisterError) {
+            // Registration ceremony failed (e.g. user cancelled biometric prompt)
+            console.error('Registration failed:', error.message);
+          } else if (error instanceof PasskeyChallengeError) {
+            // Could not obtain the WebAuthn challenge from Auth0
+            console.error('Challenge error:', error.message);
+          } else if (error instanceof PasskeyError) {
+            // General passkey error
+            console.error('Passkey error:', error.message);
+          }
+        }
+      };
+
+      const loginWithPasskey = async () => {
+        try {
+          await passkey.login();
+        } catch (error) {
+          if (error instanceof PasskeyError) {
+            console.error('Login failed:', error.message);
+          }
+        }
+      };
+
+      return { signupWithPasskey, loginWithPasskey };
+    }
+  };
+</script>
+```
+
+> **Tip:** Both `signup()` and `login()` throw an error if the user cancels the biometric prompt. Wrap calls in `try/catch` to handle cancellation, network failures, or misconfigured connections.
+
+## MyAccount API
+
+The MyAccount API lets you manage the current user's authentication methods, factors, and connected accounts directly from your Vue application.
+
+> **Note:** The MyAccount API requires the MyAccount audience (`https://{your-domain}/me/`) and the corresponding scopes in your `authorizationParams`. If your app uses a custom API audience alongside MyAccount, you will also need refresh tokens and MRRT.
+
+- [Setup](#setup-2)
+- [Factors](#factors)
+- [Authentication Methods](#authentication-methods)
+- [Enrollment](#enrollment)
+- [MyAccount Error Handling](#myaccount-error-handling)
+
+### Setup
+
+Configure your Auth0 client with the MyAccount audience and required scopes:
+
+```js
+// main.js
+import { createApp } from 'vue';
+import { createAuth0 } from '@auth0/auth0-vue';
+
+const app = createApp(App);
+
+app.use(
+  createAuth0({
+    domain: 'YOUR_AUTH0_DOMAIN',
+    clientId: 'YOUR_AUTH0_CLIENT_ID',
+    authorizationParams: {
+      redirect_uri: window.location.origin,
+      audience: 'https://YOUR_AUTH0_DOMAIN/me/',
+      scope: 'openid profile email read:me:factors read:me:authentication_methods create:me:authentication_methods update:me:authentication_methods delete:me:authentication_methods'
+    }
+  })
+);
+```
+
+### Factors
+
+Get the list of MFA factors and their enabled status for the current user.
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { myAccount } = useAuth0();
+
+      const loadFactors = async () => {
+        const factors = await myAccount.getFactors();
+        // [{ type: 'totp', usage: ['secondary'] }, ...]
+        console.log(factors);
+      };
+
+      return { loadFactors };
+    }
+  };
+</script>
+```
+
+### Authentication Methods
+
+#### List all authentication methods
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { myAccount } = useAuth0();
+
+      const loadMethods = async () => {
+        const methods = await myAccount.getAuthenticationMethods();
+        console.log(methods);
+      };
+
+      return { loadMethods };
+    }
+  };
+</script>
+```
+
+#### Get a single authentication method by ID
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { myAccount } = useAuth0();
+
+      const loadMethod = async (methodId) => {
+        const method = await myAccount.getAuthenticationMethod(methodId);
+        console.log(method);
+      };
+
+      return { loadMethod };
+    }
+  };
+</script>
+```
+
+#### Update an authentication method
+
+Currently supported for passkey methods — for example, to rename a passkey:
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { myAccount } = useAuth0();
+
+      const renamePasskey = async (methodId) => {
+        const updated = await myAccount.updateAuthenticationMethod(methodId, {
+          name: 'My Work Laptop'
+        });
+        console.log(updated);
+      };
+
+      return { renamePasskey };
+    }
+  };
+</script>
+```
+
+#### Delete an authentication method
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { myAccount } = useAuth0();
+
+      const deleteMethod = async (methodId) => {
+        await myAccount.deleteAuthenticationMethod(methodId);
+      };
+
+      return { deleteMethod };
+    }
+  };
+</script>
+```
+
+### Enrollment
+
+Enrollment is a two-step flow: request a challenge, then verify the credential.
+
+#### Passkey
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { myAccount } = useAuth0();
+
+      const enrollPasskey = async () => {
+        // Step 1: get the WebAuthn creation challenge
+        const challenge = await myAccount.enrollmentChallenge({ type: 'passkey' });
+
+        // Step 2: trigger the browser WebAuthn ceremony
+        const credential = await navigator.credentials.create({
+          publicKey: {
+            ...challenge.authn_params_public_key,
+            challenge: base64urlToBuffer(challenge.authn_params_public_key.challenge),
+            user: {
+              ...challenge.authn_params_public_key.user,
+              id: base64urlToBuffer(challenge.authn_params_public_key.user.id)
+            }
+          }
+        });
+
+        // Step 3: verify and complete enrollment
+        const method = await myAccount.enrollmentVerify({
+          type: 'passkey',
+          location: challenge.location,
+          auth_session: challenge.auth_session,
+          authn_response: serializeCredential(credential)
+        });
+
+        console.log('Enrolled passkey:', method);
+      };
+
+      return { enrollPasskey };
+    }
+  };
+</script>
+```
+
+#### Email
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { myAccount } = useAuth0();
+
+      const enrollEmail = async (email, otpCode) => {
+        // Step 1: request OTP to the email address
+        const challenge = await myAccount.enrollmentChallenge({
+          type: 'email',
+          email
+        });
+
+        // Step 2: verify with the OTP the user received
+        await myAccount.enrollmentVerify({
+          type: 'email',
+          location: challenge.location,
+          auth_session: challenge.auth_session,
+          otp_code: otpCode
+        });
+      };
+
+      return { enrollEmail };
+    }
+  };
+</script>
+```
+
+#### Phone
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { myAccount } = useAuth0();
+
+      const enrollPhone = async (phoneNumber, otpCode) => {
+        // Step 1: request OTP to the phone number
+        const challenge = await myAccount.enrollmentChallenge({
+          type: 'phone',
+          phone_number: phoneNumber,
+          preferred_authentication_method: 'sms'
+        });
+
+        // Step 2: verify with the OTP the user received
+        await myAccount.enrollmentVerify({
+          type: 'phone',
+          location: challenge.location,
+          auth_session: challenge.auth_session,
+          otp_code: otpCode
+        });
+      };
+
+      return { enrollPhone };
+    }
+  };
+</script>
+```
+
+#### TOTP (Authenticator App)
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { myAccount } = useAuth0();
+
+      const enrollTotp = async (otpCode) => {
+        // Step 1: get the TOTP secret and QR code URI
+        const challenge = await myAccount.enrollmentChallenge({ type: 'totp' });
+        // challenge.barcode_uri  — render as a QR code for the user to scan
+        // challenge.manual_input_code — fallback manual entry code
+
+        // Step 2: user scans QR code and enters the generated OTP to confirm
+        await myAccount.enrollmentVerify({
+          type: 'totp',
+          location: challenge.location,
+          auth_session: challenge.auth_session,
+          otp_code: otpCode
+        });
+      };
+
+      return { enrollTotp };
+    }
+  };
+</script>
+```
+
+### MyAccount Error Handling
+
+All MyAccount API errors throw `MyAccountApiError` with RFC 7807 fields.
+
+```html
+<script>
+  import { useAuth0, MyAccountApiError } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { myAccount } = useAuth0();
+
+      const enrollPasskey = async () => {
+        try {
+          const challenge = await myAccount.enrollmentChallenge({ type: 'passkey' });
+          // ... complete enrollment
+        } catch (err) {
+          if (err instanceof MyAccountApiError) {
+            console.error(err.status, err.title, err.detail);
+            if (err.validation_errors) {
+              err.validation_errors.forEach(e => console.error(e.field, e.detail));
+            }
+          }
+        }
+      };
+
+      const deleteMethod = async (methodId) => {
+        try {
+          await myAccount.deleteAuthenticationMethod(methodId);
+        } catch (err) {
+          if (err instanceof MyAccountApiError) {
+            console.error(err.status, err.title, err.detail);
+          }
+        }
+      };
+
+      return { enrollPasskey, deleteMethod };
+    }
+  };
+</script>
+```
+
+<details>
+  <summary>Using Options API</summary>
+
+```html
+<script>
+  import { MyAccountApiError } from '@auth0/auth0-vue';
+
+  export default {
+    methods: {
+      async loadFactors() {
+        try {
+          const factors = await this.$auth0.myAccount.getFactors();
+          console.log(factors);
+        } catch (err) {
+          if (err instanceof MyAccountApiError) {
+            console.error(err.status, err.title, err.detail);
+          }
+        }
+      },
+      async enrollPasskey() {
+        try {
+          const challenge = await this.$auth0.myAccount.enrollmentChallenge({ type: 'passkey' });
+          // ... complete enrollment
+        } catch (err) {
+          if (err instanceof MyAccountApiError) {
+            console.error(err.status, err.title, err.detail);
+          }
+        }
+      }
+    }
+  };
+</script>
+```
+
+</details>

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -2107,10 +2107,10 @@ Enrollment is a two-step flow: request a challenge, then verify the credential.
         const credential = await navigator.credentials.create({
           publicKey: {
             ...challenge.authn_params_public_key,
-            challenge: base64urlToBuffer(challenge.authn_params_public_key.challenge),
+            challenge: base64urlToBuffer(challenge.authn_params_public_key.challenge), // decode base64url → ArrayBuffer
             user: {
               ...challenge.authn_params_public_key.user,
-              id: base64urlToBuffer(challenge.authn_params_public_key.user.id)
+              id: base64urlToBuffer(challenge.authn_params_public_key.user.id) // decode base64url → ArrayBuffer
             }
           }
         });
@@ -2120,7 +2120,7 @@ Enrollment is a two-step flow: request a challenge, then verify the credential.
           type: 'passkey',
           location: challenge.location,
           auth_session: challenge.auth_session,
-          authn_response: serializeCredential(credential)
+          authn_response: serializeCredential(credential) // serialize PublicKeyCredential → plain object
         });
 
         console.log('Enrolled passkey:', method);
@@ -2131,6 +2131,10 @@ Enrollment is a two-step flow: request a challenge, then verify the credential.
   };
 </script>
 ```
+
+> **Note:** The WebAuthn API requires binary buffers for `challenge` and `user.id`, and expects a plain serializable object when sending the credential back to Auth0. You will need two small helpers:
+> - `base64urlToBuffer(str)` — converts a base64url string to `ArrayBuffer`. See [MDN: Base64 encoding and decoding](https://developer.mozilla.org/en-US/docs/Glossary/Base64) or use a library such as [`@simplewebauthn/browser`](https://simplewebauthn.dev).
+> - `serializeCredential(credential)` — converts the `PublicKeyCredential` returned by `navigator.credentials.create()` into a plain JSON-serializable object. Most WebAuthn libraries provide this out of the box.
 
 #### Email
 

--- a/__tests__/my-account.test.ts
+++ b/__tests__/my-account.test.ts
@@ -1,0 +1,289 @@
+import { App } from 'vue';
+import { createAuth0 } from '../src/index';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest
+} from '@jest/globals';
+
+const myAccountGetFactorsMock = jest.fn<any>().mockResolvedValue([{ status: 'enabled', type: 'passkey' }]);
+const myAccountGetAuthenticationMethodsMock = jest.fn<any>().mockResolvedValue([{ id: 'method-1', type: 'passkey' }]);
+const myAccountGetAuthenticationMethodMock = jest.fn<any>().mockResolvedValue({ id: 'test-method-id', type: 'passkey' });
+const myAccountUpdateAuthenticationMethodMock = jest.fn<any>().mockResolvedValue({ id: 'test-method-id', name: 'My Passkey' });
+const myAccountDeleteAuthenticationMethodMock = jest.fn<any>().mockResolvedValue(undefined);
+const myAccountEnrollmentChallengeMock = jest.fn<any>().mockResolvedValue({
+  id: 'test-challenge-id',
+  auth_session: 'test-auth-session',
+  location: 'https://example.auth0.com/me/v1/authentication-methods/test-challenge-id'
+});
+const myAccountEnrollmentVerifyMock = jest.fn<any>().mockResolvedValue({ id: 'test-method-id', type: 'passkey' });
+
+const checkSessionMock = jest.fn<any>().mockResolvedValue(null);
+const handleRedirectCallbackMock = jest.fn<any>().mockResolvedValue(null);
+const isAuthenticatedMock = jest.fn<any>().mockResolvedValue(false);
+const getUserMock = jest.fn<any>().mockResolvedValue(null);
+const getIdTokenClaimsMock = jest.fn<any>().mockResolvedValue(null);
+
+jest.mock('vue', () => {
+  const originalModule = jest.requireActual('vue');
+  return {
+    __esModule: true,
+    ...(originalModule as any),
+    inject: jest.fn()
+  };
+});
+
+jest.mock('@auth0/auth0-spa-js', () => {
+  return {
+    Auth0Client: jest.fn().mockImplementation(() => {
+      return {
+        checkSession: checkSessionMock,
+        handleRedirectCallback: handleRedirectCallbackMock,
+        loginWithRedirect: jest.fn<any>().mockResolvedValue(null),
+        loginWithPopup: jest.fn<any>().mockResolvedValue(null),
+        logout: jest.fn<any>(),
+        isAuthenticated: isAuthenticatedMock,
+        getUser: getUserMock,
+        getIdTokenClaims: getIdTokenClaimsMock,
+        getTokenSilently: jest.fn<any>().mockResolvedValue(null),
+        getTokenWithPopup: jest.fn<any>().mockResolvedValue(null),
+        getDpopNonce: jest.fn<any>().mockResolvedValue(undefined),
+        setDpopNonce: jest.fn<any>().mockResolvedValue(undefined),
+        generateDpopProof: jest.fn<any>().mockResolvedValue('mock-proof'),
+        loginWithCustomTokenExchange: jest.fn<any>().mockResolvedValue({}),
+        createFetcher: jest.fn<any>().mockReturnValue({}),
+        mfa: {
+          setMFAAuthDetails: jest.fn(),
+          getAuthenticators: jest.fn<any>().mockResolvedValue([]),
+          enroll: jest.fn<any>().mockResolvedValue({}),
+          challenge: jest.fn<any>().mockResolvedValue({}),
+          verify: jest.fn<any>().mockResolvedValue({}),
+          getEnrollmentFactors: jest.fn<any>().mockResolvedValue([])
+        },
+        passkey: {
+          signup: jest.fn<any>().mockResolvedValue({ access_token: 'passkey-token' }),
+          login: jest.fn<any>().mockResolvedValue({ access_token: 'passkey-token' })
+        },
+        myAccount: {
+          getFactors: myAccountGetFactorsMock,
+          getAuthenticationMethods: myAccountGetAuthenticationMethodsMock,
+          getAuthenticationMethod: myAccountGetAuthenticationMethodMock,
+          updateAuthenticationMethod: myAccountUpdateAuthenticationMethodMock,
+          deleteAuthenticationMethod: myAccountDeleteAuthenticationMethodMock,
+          enrollmentChallenge: myAccountEnrollmentChallengeMock,
+          enrollmentVerify: myAccountEnrollmentVerifyMock
+        }
+      };
+    }),
+    MyAccountApiError: class MyAccountApiError extends Error {
+      public type: string;
+      public status: number;
+      public title: string;
+      public detail: string;
+      constructor({ type, status, title, detail }: any) {
+        super(detail);
+        this.name = 'MyAccountApiError';
+        this.type = type;
+        this.status = status;
+        this.title = title;
+        this.detail = detail;
+      }
+    }
+  };
+});
+
+describe('MyAccount API', () => {
+  const savedLocation = window.location;
+  const savedHistory = window.history;
+  let appMock: App<any>;
+
+  beforeEach(() => {
+    delete (window as any).location;
+    window.location = Object.assign(new URL('https://example.org'), {
+      ancestorOrigins: '',
+      assign: jest.fn(),
+      reload: jest.fn(),
+      replace: jest.fn()
+    }) as any;
+
+    delete (window as any).history;
+    window.history = {
+      replaceState: jest.fn()
+    } as any;
+
+    appMock = {
+      config: {
+        globalProperties: {}
+      },
+      provide: jest.fn()
+    } as any;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: savedLocation,
+      writable: true,
+      configurable: true
+    });
+    window.history = savedHistory;
+  });
+
+  describe('Basic Availability', () => {
+    it('should expose myAccount client after plugin install', async () => {
+      const plugin = createAuth0({ domain: '', clientId: '' });
+      plugin.install(appMock);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(plugin.myAccount).toBeDefined();
+      expect(plugin.myAccount.getFactors).toBeDefined();
+      expect(plugin.myAccount.getAuthenticationMethods).toBeDefined();
+      expect(plugin.myAccount.getAuthenticationMethod).toBeDefined();
+      expect(plugin.myAccount.updateAuthenticationMethod).toBeDefined();
+      expect(plugin.myAccount.deleteAuthenticationMethod).toBeDefined();
+      expect(plugin.myAccount.enrollmentChallenge).toBeDefined();
+      expect(plugin.myAccount.enrollmentVerify).toBeDefined();
+    });
+  });
+
+  describe('getFactors', () => {
+    it('should return list of factors', async () => {
+      const plugin = createAuth0({ domain: '', clientId: '' });
+      plugin.install(appMock);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      const factors = await plugin.myAccount.getFactors();
+
+      expect(Array.isArray(factors)).toBe(true);
+      expect(myAccountGetFactorsMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('getAuthenticationMethods', () => {
+    it('should return list of authentication methods without filter', async () => {
+      const plugin = createAuth0({ domain: '', clientId: '' });
+      plugin.install(appMock);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      const methods = await plugin.myAccount.getAuthenticationMethods();
+
+      expect(Array.isArray(methods)).toBe(true);
+      expect(myAccountGetAuthenticationMethodsMock).toHaveBeenCalled();
+    });
+
+    it('should forward type filter to underlying client', async () => {
+      const plugin = createAuth0({ domain: '', clientId: '' });
+      plugin.install(appMock);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      await plugin.myAccount.getAuthenticationMethods('passkey');
+
+      expect(myAccountGetAuthenticationMethodsMock).toHaveBeenCalledWith('passkey');
+    });
+  });
+
+  describe('getAuthenticationMethod', () => {
+    it('should return a single authentication method by id', async () => {
+      const plugin = createAuth0({ domain: '', clientId: '' });
+      plugin.install(appMock);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      const method = await plugin.myAccount.getAuthenticationMethod('test-method-id');
+
+      expect(method).toBeDefined();
+      expect((method as any).id).toBe('test-method-id');
+      expect(myAccountGetAuthenticationMethodMock).toHaveBeenCalledWith('test-method-id');
+    });
+  });
+
+  describe('updateAuthenticationMethod', () => {
+    it('should update and return the authentication method', async () => {
+      const plugin = createAuth0({ domain: '', clientId: '' });
+      plugin.install(appMock);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      const updated = await plugin.myAccount.updateAuthenticationMethod('test-method-id', { name: 'My Passkey' });
+
+      expect((updated as any).id).toBe('test-method-id');
+      expect(myAccountUpdateAuthenticationMethodMock).toHaveBeenCalledWith('test-method-id', { name: 'My Passkey' });
+    });
+  });
+
+  describe('deleteAuthenticationMethod', () => {
+    it('should delete authentication method without returning a value', async () => {
+      const plugin = createAuth0({ domain: '', clientId: '' });
+      plugin.install(appMock);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      await expect(
+        plugin.myAccount.deleteAuthenticationMethod('test-method-id')
+      ).resolves.toBeUndefined();
+      expect(myAccountDeleteAuthenticationMethodMock).toHaveBeenCalledWith('test-method-id');
+    });
+  });
+
+  describe('enrollmentChallenge', () => {
+    it('should return enrollment challenge response', async () => {
+      const plugin = createAuth0({ domain: '', clientId: '' });
+      plugin.install(appMock);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      const challenge = await plugin.myAccount.enrollmentChallenge({ type: 'totp' });
+
+      expect((challenge as any).id).toBe('test-challenge-id');
+      expect((challenge as any).auth_session).toBe('test-auth-session');
+      expect(myAccountEnrollmentChallengeMock).toHaveBeenCalledWith({ type: 'totp' });
+    });
+  });
+
+  describe('enrollmentVerify', () => {
+    it('should verify enrollment and return authentication method', async () => {
+      const plugin = createAuth0({ domain: '', clientId: '' });
+      plugin.install(appMock);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      const result = await plugin.myAccount.enrollmentVerify({
+        type: 'totp',
+        location: 'https://example.auth0.com/me/v1/authentication-methods/test-challenge-id',
+        auth_session: 'test-auth-session',
+        otp_code: '123456'
+      } as any);
+
+      expect((result as any).id).toBe('test-method-id');
+      expect(myAccountEnrollmentVerifyMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should propagate errors thrown by myAccount methods', async () => {
+      const { MyAccountApiError } = await import('@auth0/auth0-spa-js') as any;
+      const error = new MyAccountApiError({
+        type: 'https://auth0.com/docs/errors#insufficient-scope',
+        status: 403,
+        title: 'Forbidden',
+        detail: 'Insufficient scope'
+      });
+      myAccountGetAuthenticationMethodsMock.mockRejectedValueOnce(error);
+
+      const plugin = createAuth0({ domain: '', clientId: '' });
+      plugin.install(appMock);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      await expect(
+        plugin.myAccount.getAuthenticationMethods()
+      ).rejects.toBeInstanceOf(MyAccountApiError);
+    });
+  });
+});

--- a/__tests__/passkey.test.ts
+++ b/__tests__/passkey.test.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue';
-import { createAuth0, useAuth0 } from '../src/index';
+import { createAuth0 } from '../src/index';
 import {
   afterEach,
   beforeEach,
@@ -8,7 +8,6 @@ import {
   it,
   jest
 } from '@jest/globals';
-import { inject } from 'vue';
 
 const passkeySignupMock = jest
   .fn<any>()

--- a/__tests__/passkey.test.ts
+++ b/__tests__/passkey.test.ts
@@ -173,6 +173,19 @@ describe('Passkey API', () => {
         plugin.passkey.signup({ email: 'user@example.com' })
       ).rejects.toThrow('WebAuthn not supported');
     });
+
+    it('should update isAuthenticated and user after passkey.signup', async () => {
+      const plugin = createAuth0({ domain: '', clientId: '' });
+      plugin.install(appMock);
+
+      isAuthenticatedMock.mockResolvedValue(true);
+      getUserMock.mockResolvedValue({ name: '__test_user__' });
+
+      await plugin.passkey.signup({ email: 'user@example.com' });
+
+      expect(plugin.isAuthenticated.value).toEqual(true);
+      expect(plugin.user.value).toEqual({ name: '__test_user__' });
+    });
   });
 
   describe('passkey.login', () => {
@@ -210,6 +223,19 @@ describe('Passkey API', () => {
       await new Promise(resolve => setTimeout(resolve, 0));
 
       await expect(plugin.passkey.login()).rejects.toThrow('User cancelled');
+    });
+
+    it('should update isAuthenticated and user after passkey.login', async () => {
+      const plugin = createAuth0({ domain: '', clientId: '' });
+      plugin.install(appMock);
+
+      isAuthenticatedMock.mockResolvedValue(true);
+      getUserMock.mockResolvedValue({ name: '__test_user__' });
+
+      await plugin.passkey.login();
+
+      expect(plugin.isAuthenticated.value).toEqual(true);
+      expect(plugin.user.value).toEqual({ name: '__test_user__' });
     });
   });
 });

--- a/__tests__/passkey.test.ts
+++ b/__tests__/passkey.test.ts
@@ -1,0 +1,216 @@
+import { App } from 'vue';
+import { createAuth0, useAuth0 } from '../src/index';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest
+} from '@jest/globals';
+import { inject } from 'vue';
+
+const passkeySignupMock = jest
+  .fn<any>()
+  .mockResolvedValue({ access_token: 'passkey-token', id_token: 'passkey-id-token' });
+const passkeyLoginMock = jest
+  .fn<any>()
+  .mockResolvedValue({ access_token: 'passkey-token', id_token: 'passkey-id-token' });
+
+const checkSessionMock = jest.fn<any>().mockResolvedValue(null);
+const handleRedirectCallbackMock = jest.fn<any>().mockResolvedValue(null);
+const isAuthenticatedMock = jest.fn<any>().mockResolvedValue(false);
+const getUserMock = jest.fn<any>().mockResolvedValue(null);
+const getIdTokenClaimsMock = jest.fn<any>().mockResolvedValue(null);
+
+jest.mock('vue', () => {
+  const originalModule = jest.requireActual('vue');
+  return {
+    __esModule: true,
+    ...(originalModule as any),
+    inject: jest.fn()
+  };
+});
+
+jest.mock('@auth0/auth0-spa-js', () => {
+  return {
+    Auth0Client: jest.fn().mockImplementation(() => {
+      return {
+        checkSession: checkSessionMock,
+        handleRedirectCallback: handleRedirectCallbackMock,
+        loginWithRedirect: jest.fn<any>().mockResolvedValue(null),
+        loginWithPopup: jest.fn<any>().mockResolvedValue(null),
+        logout: jest.fn<any>(),
+        isAuthenticated: isAuthenticatedMock,
+        getUser: getUserMock,
+        getIdTokenClaims: getIdTokenClaimsMock,
+        getTokenSilently: jest.fn<any>().mockResolvedValue(null),
+        getTokenWithPopup: jest.fn<any>().mockResolvedValue(null),
+        getDpopNonce: jest.fn<any>().mockResolvedValue(undefined),
+        setDpopNonce: jest.fn<any>().mockResolvedValue(undefined),
+        generateDpopProof: jest.fn<any>().mockResolvedValue('mock-proof'),
+        loginWithCustomTokenExchange: jest.fn<any>().mockResolvedValue({}),
+        createFetcher: jest.fn<any>().mockReturnValue({}),
+        mfa: {
+          setMFAAuthDetails: jest.fn(),
+          getAuthenticators: jest.fn<any>().mockResolvedValue([]),
+          enroll: jest.fn<any>().mockResolvedValue({}),
+          challenge: jest.fn<any>().mockResolvedValue({}),
+          verify: jest.fn<any>().mockResolvedValue({}),
+          getEnrollmentFactors: jest.fn<any>().mockResolvedValue([])
+        },
+        passkey: {
+          signup: passkeySignupMock,
+          login: passkeyLoginMock
+        },
+        myAccount: {
+          getFactors: jest.fn<any>().mockResolvedValue([]),
+          getAuthenticationMethods: jest.fn<any>().mockResolvedValue([]),
+          getAuthenticationMethod: jest.fn<any>().mockResolvedValue({ id: 'test-id' }),
+          updateAuthenticationMethod: jest.fn<any>().mockResolvedValue({ id: 'test-id' }),
+          deleteAuthenticationMethod: jest.fn<any>().mockResolvedValue(undefined),
+          enrollmentChallenge: jest.fn<any>().mockResolvedValue({ id: 'test-challenge-id', auth_session: 'test-session' }),
+          enrollmentVerify: jest.fn<any>().mockResolvedValue({ id: 'test-method-id' })
+        }
+      };
+    }),
+    PasskeyError: class PasskeyError extends Error {
+      constructor(public code: string, message: string) {
+        super(message);
+        this.name = 'PasskeyError';
+      }
+    },
+    PasskeyRegisterError: class PasskeyRegisterError extends Error {},
+    PasskeyChallengeError: class PasskeyChallengeError extends Error {},
+    PasskeyGetTokenError: class PasskeyGetTokenError extends Error {}
+  };
+});
+
+describe('Passkey API', () => {
+  const savedLocation = window.location;
+  const savedHistory = window.history;
+  let appMock: App<any>;
+
+  beforeEach(() => {
+    delete (window as any).location;
+    window.location = Object.assign(new URL('https://example.org'), {
+      ancestorOrigins: '',
+      assign: jest.fn(),
+      reload: jest.fn(),
+      replace: jest.fn()
+    }) as any;
+
+    delete (window as any).history;
+    window.history = {
+      replaceState: jest.fn()
+    } as any;
+
+    appMock = {
+      config: {
+        globalProperties: {}
+      },
+      provide: jest.fn()
+    } as any;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: savedLocation,
+      writable: true,
+      configurable: true
+    });
+    window.history = savedHistory;
+  });
+
+  describe('Basic Availability', () => {
+    it('should expose passkey client after plugin install', async () => {
+      const plugin = createAuth0({ domain: '', clientId: '' });
+      plugin.install(appMock);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(plugin.passkey).toBeDefined();
+      expect(plugin.passkey.signup).toBeDefined();
+      expect(plugin.passkey.login).toBeDefined();
+    });
+  });
+
+  describe('passkey.signup', () => {
+    it('should return token response', async () => {
+      const plugin = createAuth0({ domain: '', clientId: '' });
+      plugin.install(appMock);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      const tokenResponse = await plugin.passkey.signup({ email: 'user@example.com' });
+
+      expect(tokenResponse).toBeDefined();
+      expect(tokenResponse.access_token).toBe('passkey-token');
+      expect(tokenResponse.id_token).toBe('passkey-id-token');
+    });
+
+    it('should forward options to underlying passkey client', async () => {
+      const plugin = createAuth0({ domain: '', clientId: '' });
+      plugin.install(appMock);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      await plugin.passkey.signup({ email: 'user@example.com', realm: 'Username-Password-Authentication' });
+
+      expect(passkeySignupMock).toHaveBeenCalledWith(
+        expect.objectContaining({ email: 'user@example.com', realm: 'Username-Password-Authentication' })
+      );
+    });
+
+    it('should rethrow errors from passkey.signup', async () => {
+      passkeySignupMock.mockRejectedValueOnce(new Error('WebAuthn not supported'));
+
+      const plugin = createAuth0({ domain: '', clientId: '' });
+      plugin.install(appMock);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      await expect(
+        plugin.passkey.signup({ email: 'user@example.com' })
+      ).rejects.toThrow('WebAuthn not supported');
+    });
+  });
+
+  describe('passkey.login', () => {
+    it('should return token response', async () => {
+      const plugin = createAuth0({ domain: '', clientId: '' });
+      plugin.install(appMock);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      const tokenResponse = await plugin.passkey.login();
+
+      expect(tokenResponse).toBeDefined();
+      expect(tokenResponse.access_token).toBe('passkey-token');
+    });
+
+    it('should forward options to underlying passkey client', async () => {
+      const plugin = createAuth0({ domain: '', clientId: '' });
+      plugin.install(appMock);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      await plugin.passkey.login({ realm: 'Username-Password-Authentication', scope: 'openid profile email' });
+
+      expect(passkeyLoginMock).toHaveBeenCalledWith(
+        expect.objectContaining({ realm: 'Username-Password-Authentication', scope: 'openid profile email' })
+      );
+    });
+
+    it('should rethrow errors from passkey.login', async () => {
+      passkeyLoginMock.mockRejectedValueOnce(new Error('User cancelled'));
+
+      const plugin = createAuth0({ domain: '', clientId: '' });
+      plugin.install(appMock);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      await expect(plugin.passkey.login()).rejects.toThrow('User cancelled');
+    });
+  });
+});

--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -73,6 +73,19 @@ jest.mock('@auth0/auth0-spa-js', () => {
           challenge: jest.fn<any>().mockResolvedValue({}),
           verify: jest.fn<any>().mockResolvedValue({}),
           getEnrollmentFactors: jest.fn<any>().mockResolvedValue([])
+        },
+        passkey: {
+          signup: jest.fn<any>().mockResolvedValue({ access_token: 'passkey-token' }),
+          login: jest.fn<any>().mockResolvedValue({ access_token: 'passkey-token' })
+        },
+        myAccount: {
+          getFactors: jest.fn<any>().mockResolvedValue([]),
+          getAuthenticationMethods: jest.fn<any>().mockResolvedValue([]),
+          getAuthenticationMethod: jest.fn<any>().mockResolvedValue({ id: 'test-id' }),
+          updateAuthenticationMethod: jest.fn<any>().mockResolvedValue({ id: 'test-id' }),
+          deleteAuthenticationMethod: jest.fn<any>().mockResolvedValue(undefined),
+          enrollmentChallenge: jest.fn<any>().mockResolvedValue({ id: 'test-challenge-id' }),
+          enrollmentVerify: jest.fn<any>().mockResolvedValue({ id: 'test-method-id' })
         }
       };
     })
@@ -94,6 +107,26 @@ describe('Client', () => {
     const spy = jest.spyOn(console, 'error');
 
     await client.value.mfa.getAuthenticators('test-token');
+
+    expect(spy).toHaveBeenCalledWith(
+      `Please ensure Auth0's Vue plugin is correctly installed.`
+    );
+  });
+
+  it('logs console error when passkey methods are called before installing the plugin', async () => {
+    const spy = jest.spyOn(console, 'error');
+
+    await client.value.passkey.signup({ email: 'user@example.com' } as any);
+
+    expect(spy).toHaveBeenCalledWith(
+      `Please ensure Auth0's Vue plugin is correctly installed.`
+    );
+  });
+
+  it('logs console error when myAccount methods are called before installing the plugin', async () => {
+    const spy = jest.spyOn(console, 'error');
+
+    await client.value.myAccount.getFactors();
 
     expect(spy).toHaveBeenCalledWith(
       `Please ensure Auth0's Vue plugin is correctly installed.`

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "wait-on": "^7.2.0"
   },
   "dependencies": {
-    "@auth0/auth0-spa-js": "^2.10.0",
+    "@auth0/auth0-spa-js": "^2.21.0",
     "vue": "^3.5.21"
   },
   "peerDependencies": {

--- a/src/global.ts
+++ b/src/global.ts
@@ -13,7 +13,12 @@ export {
   MfaEnrollmentError,
   MfaChallengeError,
   MfaVerifyError,
-  MfaEnrollmentFactorsError
+  MfaEnrollmentFactorsError,
+  PasskeyError,
+  PasskeyRegisterError,
+  PasskeyChallengeError,
+  PasskeyGetTokenError,
+  MyAccountApiError
 } from '@auth0/auth0-spa-js';
 
 export type {
@@ -51,5 +56,16 @@ export type {
   ChallengeResponse,
   VerifyParams,
   MfaGrantType,
-  EnrollmentFactor
+  EnrollmentFactor,
+  PasskeyApiClient,
+  PasskeySignupOptions,
+  PasskeyLoginOptions,
+  MyAccountApiClient,
+  AuthenticationMethod,
+  AuthenticationMethodType,
+  Factor,
+  UpdateAuthenticationMethodRequest,
+  EnrollmentChallengeOptions,
+  EnrollmentChallengeResponse,
+  EnrollmentVerifyOptions
 } from '@auth0/auth0-spa-js';

--- a/src/interfaces/auth0-vue-client.ts
+++ b/src/interfaces/auth0-vue-client.ts
@@ -351,8 +351,8 @@ export interface Auth0VueClient {
    * credential ceremony → token exchange) and automatically update
    * `isAuthenticated`, `user`, and `idTokenClaims` on completion.
    *
-   * **Note:** Errors thrown by `passkey` methods are **not** captured in the
-   * `error` ref. Always wrap calls in a `try/catch` and handle typed passkey
+   * **Note:** Errors thrown by `passkey` methods are captured in the `error`
+   * ref. You can also wrap calls in a `try/catch` to handle typed passkey
    * errors (e.g. `PasskeyError`, `PasskeyRegisterError`) directly in your component.
    *
    * ```js
@@ -391,7 +391,7 @@ export interface Auth0VueClient {
    * - `enrollmentVerify(options)` — complete enrollment by verifying the challenge
    *
    * **Note:** MyAccount API calls require an access token with the appropriate
-   * scope (e.g. `read:me:authentication-methods`). Use MRRT to exchange a
+   * scope (e.g. `read:me:authentication_methods`). Use MRRT to exchange a
    * refresh token for a scoped access token if needed.
    *
    * ```js

--- a/src/interfaces/auth0-vue-client.ts
+++ b/src/interfaces/auth0-vue-client.ts
@@ -14,7 +14,9 @@ import type {
   FetcherConfig,
   MfaApiClient,
   CustomTokenExchangeOptions,
-  TokenEndpointResponse
+  TokenEndpointResponse,
+  PasskeyApiClient,
+  MyAccountApiClient
 } from '@auth0/auth0-spa-js';
 import type { Ref } from 'vue';
 import type { AppState } from './app-state';
@@ -333,4 +335,75 @@ export interface Auth0VueClient {
    * ```
    */
   mfa: MfaApiClient;
+
+  /**
+   * ```js
+   * const { passkey } = useAuth0();
+   * const tokens = await passkey.signup({ email: 'user@example.com' });
+   * ```
+   *
+   * Passkey API client for WebAuthn-based passwordless authentication.
+   *
+   * - `signup(options)` — register a new user and create a passkey credential
+   * - `login(options?)` — authenticate an existing user via passkey assertion
+   *
+   * Both methods handle the full WebAuthn flow internally (challenge → browser
+   * credential ceremony → token exchange) and update `isAuthenticated` / `user`
+   * in the same way as `loginWithPopup`.
+   *
+   * **Note:** Errors thrown by `passkey` methods are **not** captured in the
+   * `error` ref. Always wrap calls in a `try/catch` and handle typed passkey
+   * errors (e.g. `PasskeyError`, `PasskeyRegisterError`) directly in your component.
+   *
+   * ```js
+   * import { PasskeyError } from '@auth0/auth0-vue';
+   *
+   * const { passkey } = useAuth0();
+   *
+   * try {
+   *   const tokens = await passkey.signup({ email: 'user@example.com' });
+   * } catch (e) {
+   *   if (e instanceof PasskeyError) {
+   *     // handle passkey-specific errors
+   *   }
+   * }
+   * ```
+   */
+  passkey: PasskeyApiClient;
+
+  /**
+   * ```js
+   * const { myAccount } = useAuth0();
+   * const factors = await myAccount.getFactors();
+   * ```
+   *
+   * MyAccount API client for self-service account management operations.
+   *
+   * Provides methods for managing the authenticated user's authentication
+   * methods and factors:
+   * - `getFactors()` — list all enabled factors and those available for enrollment
+   * - `getAuthenticationMethods(type?)` — list enrolled authentication methods, optionally filtered by type
+   * - `getAuthenticationMethod(id)` — get a single authentication method by ID
+   * - `updateAuthenticationMethod(id, data)` — update an authentication method (e.g. rename)
+   * - `deleteAuthenticationMethod(id)` — remove an enrolled authentication method
+   * - `enrollmentChallenge(options)` — initiate a two-step enrollment challenge
+   * - `enrollmentVerify(options)` — complete enrollment by verifying the challenge
+   *
+   * **Note:** MyAccount API calls require an access token with the appropriate
+   * scope (e.g. `read:me:authentication-methods`). Use MRRT to exchange a
+   * refresh token for a scoped access token if needed.
+   *
+   * ```js
+   * const { myAccount } = useAuth0();
+   *
+   * // List passkey authentication methods
+   * const methods = await myAccount.getAuthenticationMethods('passkey');
+   *
+   * // Enroll a new passkey
+   * const challenge = await myAccount.enrollmentChallenge({ type: 'passkey' });
+   * const credential = await navigator.credentials.create({ publicKey: challenge.authn_params_public_key });
+   * await myAccount.enrollmentVerify({ type: 'passkey', auth_session: challenge.auth_session, location: challenge.location, authn_response: credential });
+   * ```
+   */
+  myAccount: MyAccountApiClient;
 }

--- a/src/interfaces/auth0-vue-client.ts
+++ b/src/interfaces/auth0-vue-client.ts
@@ -348,12 +348,8 @@ export interface Auth0VueClient {
    * - `login(options?)` — authenticate an existing user via passkey assertion
    *
    * Both methods handle the full WebAuthn flow internally (challenge → browser
-   * credential ceremony → token exchange).
-   *
-   * **Note:** `passkey.signup()` and `passkey.login()` do not automatically
-   * update Vue's reactive state (`isAuthenticated`, `user`, `idTokenClaims`).
-   * Call `checkSession()` after a successful passkey operation to reflect the
-   * new session in your components.
+   * credential ceremony → token exchange) and automatically update
+   * `isAuthenticated`, `user`, and `idTokenClaims` on completion.
    *
    * **Note:** Errors thrown by `passkey` methods are **not** captured in the
    * `error` ref. Always wrap calls in a `try/catch` and handle typed passkey
@@ -362,11 +358,11 @@ export interface Auth0VueClient {
    * ```js
    * import { PasskeyError } from '@auth0/auth0-vue';
    *
-   * const { passkey, checkSession } = useAuth0();
+   * const { passkey } = useAuth0();
    *
    * try {
    *   await passkey.signup({ email: 'user@example.com' });
-   *   await checkSession(); // refresh isAuthenticated, user, etc.
+   *   // isAuthenticated, user, and idTokenClaims are updated automatically
    * } catch (e) {
    *   if (e instanceof PasskeyError) {
    *     // handle passkey-specific errors

--- a/src/interfaces/auth0-vue-client.ts
+++ b/src/interfaces/auth0-vue-client.ts
@@ -348,8 +348,12 @@ export interface Auth0VueClient {
    * - `login(options?)` — authenticate an existing user via passkey assertion
    *
    * Both methods handle the full WebAuthn flow internally (challenge → browser
-   * credential ceremony → token exchange) and update `isAuthenticated` / `user`
-   * in the same way as `loginWithPopup`.
+   * credential ceremony → token exchange).
+   *
+   * **Note:** `passkey.signup()` and `passkey.login()` do not automatically
+   * update Vue's reactive state (`isAuthenticated`, `user`, `idTokenClaims`).
+   * Call `checkSession()` after a successful passkey operation to reflect the
+   * new session in your components.
    *
    * **Note:** Errors thrown by `passkey` methods are **not** captured in the
    * `error` ref. Always wrap calls in a `try/catch` and handle typed passkey
@@ -358,10 +362,11 @@ export interface Auth0VueClient {
    * ```js
    * import { PasskeyError } from '@auth0/auth0-vue';
    *
-   * const { passkey } = useAuth0();
+   * const { passkey, checkSession } = useAuth0();
    *
    * try {
-   *   const tokens = await passkey.signup({ email: 'user@example.com' });
+   *   await passkey.signup({ email: 'user@example.com' });
+   *   await checkSession(); // refresh isAuthenticated, user, etc.
    * } catch (e) {
    *   if (e instanceof PasskeyError) {
    *     // handle passkey-specific errors

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -25,7 +25,9 @@ import type {
   CustomFetchMinimalOutput,
   MfaApiClient,
   CustomTokenExchangeOptions,
-  TokenEndpointResponse
+  TokenEndpointResponse,
+  PasskeyApiClient,
+  MyAccountApiClient
 } from '@auth0/auth0-spa-js';
 import { Auth0Client, User } from '@auth0/auth0-spa-js';
 import { bindPluginMethods, deprecateRedirectUri } from './utils';
@@ -66,7 +68,20 @@ const PLUGIN_NOT_INSTALLED_CLIENT: Auth0VueClient = {
     challenge: PLUGIN_NOT_INSTALLED_HANDLER,
     verify: PLUGIN_NOT_INSTALLED_HANDLER,
     getEnrollmentFactors: PLUGIN_NOT_INSTALLED_HANDLER
-  } as unknown as MfaApiClient
+  } as unknown as MfaApiClient,
+  passkey: {
+    signup: PLUGIN_NOT_INSTALLED_HANDLER,
+    login: PLUGIN_NOT_INSTALLED_HANDLER
+  } as unknown as PasskeyApiClient,
+  myAccount: {
+    getFactors: PLUGIN_NOT_INSTALLED_HANDLER,
+    getAuthenticationMethods: PLUGIN_NOT_INSTALLED_HANDLER,
+    getAuthenticationMethod: PLUGIN_NOT_INSTALLED_HANDLER,
+    updateAuthenticationMethod: PLUGIN_NOT_INSTALLED_HANDLER,
+    deleteAuthenticationMethod: PLUGIN_NOT_INSTALLED_HANDLER,
+    enrollmentChallenge: PLUGIN_NOT_INSTALLED_HANDLER,
+    enrollmentVerify: PLUGIN_NOT_INSTALLED_HANDLER
+  } as unknown as MyAccountApiClient
 };
 
 /**
@@ -88,6 +103,8 @@ export class Auth0Plugin implements Auth0VueClient {
   public idTokenClaims = ref<IdToken | undefined>();
   public error = ref<Error | null>(null);
   public mfa: MfaApiClient = PLUGIN_NOT_INSTALLED_CLIENT.mfa;
+  public passkey: PasskeyApiClient = PLUGIN_NOT_INSTALLED_CLIENT.passkey;
+  public myAccount: MyAccountApiClient = PLUGIN_NOT_INSTALLED_CLIENT.myAccount;
 
   constructor(
     private clientOptions: Auth0VueClientOptions,
@@ -108,6 +125,8 @@ export class Auth0Plugin implements Auth0VueClient {
     });
 
     this.mfa = this._client.mfa;
+    this.passkey = this._client.passkey;
+    this.myAccount = this._client.myAccount;
 
     this.__checkSession(app.config.globalProperties.$router);
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -27,6 +27,8 @@ import type {
   CustomTokenExchangeOptions,
   TokenEndpointResponse,
   PasskeyApiClient,
+  PasskeySignupOptions,
+  PasskeyLoginOptions,
   MyAccountApiClient
 } from '@auth0/auth0-spa-js';
 import { Auth0Client, User } from '@auth0/auth0-spa-js';
@@ -125,8 +127,13 @@ export class Auth0Plugin implements Auth0VueClient {
     });
 
     this.mfa = this._client.mfa;
-    this.passkey = this._client.passkey;
     this.myAccount = this._client.myAccount;
+
+    const passkeyClient = this._client.passkey;
+    this.passkey = {
+      signup: (options: PasskeySignupOptions) => this.__proxy(() => passkeyClient.signup(options)),
+      login: (options?: PasskeyLoginOptions) => this.__proxy(() => passkeyClient.login(options))
+    } as unknown as PasskeyApiClient;
 
     this.__checkSession(app.config.globalProperties.$router);
 


### PR DESCRIPTION
## Summary

Implements Passkeys and MyAccount API support for `auth0-vue`.

### What's new

**Passkey API** — accessible via `const { passkey } = useAuth0()`
- `passkey.signup(options)` — registers a new user with a passkey (full WebAuthn flow: challenge → credential creation → token exchange)
- `passkey.login(options?)` — authenticates an existing user via passkey assertion

**MyAccount API** — accessible via `const { myAccount } = useAuth0()`
- `myAccount.getFactors()` — list all enabled factors and those available for enrollment
- `myAccount.getAuthenticationMethods(type?)` — list enrolled authentication methods, optionally filtered by type
- `myAccount.getAuthenticationMethod(id)` — get a single authentication method by ID
- `myAccount.updateAuthenticationMethod(id, data)` — update an authentication method (e.g. rename)
- `myAccount.deleteAuthenticationMethod(id)` — remove an enrolled authentication method
- `myAccount.enrollmentChallenge(options)` — start a two-step enrollment challenge
- `myAccount.enrollmentVerify(options)` — complete enrollment by verifying the challenge

**New error classes and types exported from `@auth0/auth0-vue`:**
- `PasskeyError`, `PasskeyRegisterError`, `PasskeyChallengeError`, `PasskeyGetTokenError`
- `MyAccountApiError`
- All associated request/response types (`PasskeySignupOptions`, `PasskeyLoginOptions`, `AuthenticationMethod`, `Factor`, `EnrollmentChallengeOptions`, `EnrollmentChallengeResponse`, `EnrollmentVerifyOptions`, etc.)

### Implementation approach

Both `passkey` and `myAccount` are thin delegations to the underlying `auth0-spa-js` client properties — the same pattern used for `mfa`. The full WebAuthn ceremony (base64url encoding, `navigator.credentials` calls, token exchange) is handled inside `auth0-spa-js`, the Vue SDK just wires up access via `useAuth0()`.

## Changes

| File | Change |
|------|--------|
| `package.json` | Bump `@auth0/auth0-spa-js` dep `^2.10.0` → `^2.21.0` (passkeys shipped in v2.21.0) |
| `src/interfaces/auth0-vue-client.ts` | Add `passkey: PasskeyApiClient` and `myAccount: MyAccountApiClient` with full JSDoc |
| `src/plugin.ts` | Add public class fields; wire up in `install()`; add stubs to `PLUGIN_NOT_INSTALLED_CLIENT` |
| `src/global.ts` | Re-export passkey/myAccount error classes and types |
| `__tests__/passkey.test.ts` | New — tests for signup, login, option forwarding, error propagation |
| `__tests__/my-account.test.ts` | New — tests for all 7 myAccount methods + error handling |
| `__tests__/plugin.test.ts` | Add not-installed guard tests for `passkey` and `myAccount` |

## Test plan

- [ ] All 111 unit tests pass (`npm test`)
- [ ] `passkey.signup()` and `passkey.login()` are accessible via `useAuth0()`
- [ ] All `myAccount` methods are accessible via `useAuth0()`
- [ ] Typed passkey/myAccount errors (`PasskeyError`, `MyAccountApiError`) can be imported from `@auth0/auth0-vue`
- [ ] Calling `passkey` or `myAccount` methods before plugin install logs the expected console error

### Manual Testing

All methods were tested end-to-end against a real Auth0 tenant using a Vue app with the local SDK build.

**Passkey API**

- `passkey.signup()` — registered a new Auth0 user via WebAuthn credential creation ceremony; verified tokens returned and user created in tenant
- `passkey.login()` — authenticated an existing passkey user via WebAuthn assertion ceremony; verified tokens returned
- Reactive state (`isAuthenticated`, `user`) — verified both update correctly after passkey signup and login automatically via `__proxy()` (no manual `checkSession()` needed)

**MyAccount API**

- `myAccount.getFactors()` — verified MFA factors returned for authenticated user
- `myAccount.getAuthenticationMethods()` — verified full list of enrolled authentication methods returned
- `myAccount.getAuthenticationMethod(id)` — verified single method retrieved by ID
- `myAccount.updateAuthenticationMethod(id, body)` — verified `preferred_authentication_method` update for phone; confirmed expected error returned for unsupported method types
- `myAccount.deleteAuthenticationMethod(id)` — verified method deleted and confirmed removal via subsequent `getAuthenticationMethods()` call
- `myAccount.enrollmentChallenge({ type: 'passkey' })` — verified WebAuthn creation challenge returned with correct RP ID matching custom domain
- `myAccount.enrollmentVerify(...)` — completed full passkey enrollment ceremony; verified new passkey method created and returned with correct `relying_party_id`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for passkey sign-up and login flows.
  * Added a new account-management client with tools for listing and updating authentication methods, managing factors, and enrolling credentials.
* **Documentation**
  * Expanded examples with passkey setup, MFA step-up handling, and MyAccount API usage.
  * Added end-to-end examples and error-handling guidance.
* **Tests**
  * Added coverage for passkey and account-management behavior, including error propagation and pre-install usage warnings.
* **Chores**
  * Updated the Auth0 SPA dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->