### PR TITLE
fix: prevent script injection in GitHub Actions workflows

### DIFF
--- a/.github/actions/rl-scanner/action.yml
+++ b/.github/actions/rl-scanner/action.yml
@@ -40,16 +40,18 @@ runs:
         RLSECURE_SITE_KEY: ${{ env.RLSECURE_SITE_KEY }}
         SIGNAL_HANDLER_TOKEN: ${{ env.SIGNAL_HANDLER_TOKEN }}
         PYTHONUNBUFFERED: 1
+        ARTIFACT_PATH: ${{ inputs.artifact-path }}
+        VERSION: ${{ inputs.version }}
       run: |
-        if [ ! -f "${{ inputs.artifact-path }}" ]; then
-          echo "Artifact not found: ${{ inputs.artifact-path }}"
+        if [ ! -f "$ARTIFACT_PATH" ]; then
+          echo "Artifact not found: $ARTIFACT_PATH"
           exit 1
         fi
 
         rl-wrapper \
-          --artifact "${{ inputs.artifact-path }}" \
+          --artifact "$ARTIFACT_PATH" \
           --name "${{ github.event.repository.name }}" \
-          --version "${{ inputs.version }}" \
+          --version "$VERSION" \
           --repository "${{ github.repository }}" \
           --commit "${{ github.sha }}" \
           --build-env "github_actions" \

--- a/.github/workflows/rl-secure.yml
+++ b/.github/workflows/rl-secure.yml
@@ -43,8 +43,10 @@ jobs:
           node: ${{ inputs.node-version }}
 
       - name: Create tgz build artifact
+        env:
+          ARTIFACT_NAME: ${{ inputs.artifact-name }}
         run: |
-          tar -czvf ${{ inputs.artifact-name }} *
+          tar -czvf "$ARTIFACT_NAME" *
 
       - id: get_version
         uses: ./.github/actions/get-version
@@ -53,7 +55,7 @@ jobs:
         id: rl-scan-conclusion
         uses: ./.github/actions/rl-scanner
         with:
-          artifact-path: "$(pwd)/${{ inputs.artifact-name }}"
+          artifact-path: "${{ github.workspace }}/${{ inputs.artifact-name }}"
           version: "${{ steps.get_version.outputs.version }}"
         env:
           RLSECURE_LICENSE: ${{ secrets.RLSECURE_LICENSE }}


### PR DESCRIPTION
## Summary

Fixes GitHub Actions script injection vulnerabilities in the RL Scanner workflows.

Interpolating `${{ inputs.* }}` directly into `run:` scripts allows shell metacharacters in user-controlled input to break out of the intended command context. This fix routes those values through `env:` variables so they are treated as data, not inline script.

### Changes

- `.github/actions/rl-scanner/action.yml` — move `inputs.artifact-path` and `inputs.version` into `env:` block; reference as `$ARTIFACT_PATH` and `$VERSION` in the shell script
- `.github/workflows/rl-secure.yml` — move `inputs.artifact-name` into `env:` block for the `tar` step; replace `$(pwd)/${{ inputs.artifact-name }}` with `${{ github.workspace }}/${{ inputs.artifact-name }}` for correct path resolution

### Security impact

Before this fix, a crafted `artifact-name`, `artifact-path`, or `version` input value containing shell metacharacters (e.g. `` ` ``, `$(...)`, `;`) could execute arbitrary shell commands in the runner context.

## References

- [GitHub docs: use an intermediate environment variable](https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable)

## Test plan

- [ ] Confirm CI passes on this branch
- [ ] Verify RL Scanner workflow runs successfully on a release branch trigger