### PR TITLE
chore(deps): bump nanoid to 3.3.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10554,8 +10554,8 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -10815,8 +10815,8 @@
       }
     },
     "node_modules/oidc-provider/node_modules/nanoid": {
-      "version": "6.0.0",
-      "integrity": "sha512-mkUH+rPkwU2qPadJ0oJZOjeZ5Mxn8Q1UhevwkTRWNuUZzyia3h4rhzK39hxaHTk0o2OxB8W2SQ6A8k23ZDi1pQ==",
+      "version": "6.0.1",
+      "integrity": "sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Bumps `nanoid` from `3.3.16` to `3.3.17` in the lockfile.

`nanoid@3.3.17` fixes two high severity infinite loop vulnerabilities:
- [SNYK-JS-NANOID-18506894](https://security.snyk.io/vuln/SNYK-JS-NANOID-18506894)
- [SNYK-JS-NANOID-18506897](https://security.snyk.io/vuln/SNYK-JS-NANOID-18506897)

Also bumps `oidc-provider`'s nested `nanoid` from `6.0.0` to `6.0.1` (dev-only).

## ⚠️ Snyk check

The Snyk CI check will show as failed on this PR. This is a **false positive** — Snyk's vulnerability database has not yet been updated to recognise `nanoid@3.3.17` as the v3 backport fix. It currently only lists `5.1.16` (v5 branch) as the fixed version.

The `3.3.17` release was published on 2026-08-03 and explicitly patches the infinite loop on `size <= 0` in `customRandom`. See [nanoid#605](https://github.com/ai/nanoid/issues/605) and the [3.3.17 release](https://github.com/ai/nanoid/releases/tag/3.3.17) for details.

Snyk's DB is expected to catch up shortly, at which point the check will pass retroactively.