### PR TITLE
chore: group @typescript-eslint deps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
     directory: "/"
     schedule:
         interval: "daily"
+    groups:
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Group `@typescript-eslint/parser` and `@typescript-eslint/eslint-plugin` into a single Dependabot PR since they are always versioned together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Grouped related TypeScript linting dependency updates together for more streamlined maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->