### PR TITLE
chore: skip coderabbit on dependabot and release PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,9 @@
 reviews:
   auto_review:
-    base_branches:
-      - '^(?!release/).*'
+    ignore_title_keywords:
+      - 'build(deps)'
+      - 'build(deps-dev)'
+      - 'chore(release)'
   path_filters:
     - '!dist/**'
     - '!CHANGELOG.md'


### PR DESCRIPTION
## Summary
- Removes ineffective `base_branches` regex that was not filtering release PRs (which target `main`, not `release/**`)
- Adds `ignore_title_keywords` to skip CodeRabbit auto-review on dependabot PRs (`build(deps)`, `build(deps-dev)`) and release PRs (`chore(release)`)