### PR TITLE
feat: add Enterprise Connect support

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -606,6 +606,135 @@ Accept a user invitation through the SDK by creating a route within your applica
 </script>
 ```
 
+## Enterprise Connect
+
+Enterprise Connect lets a B2B SaaS layer enterprise SSO (SAML, OIDC federation) on top of its own auth server without replacing it. Auth0 acts as a relay: it authenticates the enterprise user against their IdP and returns an enriched ID token, which the SDK caches like any other login.
+
+> [!IMPORTANT]
+> Enterprise Connect is an Early Access feature. The tenant setup (entitlements, connection type, and the claims a token carries) depends on your Auth0 configuration and may change. Confirm the tenant-side requirements with your Auth0 contact. The SDK surface described here is stable.
+
+### How the flow works
+
+1. The user enters their email. Your app calls `isFederatedDomain` with the email domain to run [WebFinger](https://datatracker.ietf.org/doc/html/rfc7033) discovery.
+2. If the domain is managed by Auth0 for enterprise SSO, call `loginWithRedirect` with the email as `login_hint` so Auth0 can resolve the connection and organization. If it is not managed, fall back to your own login.
+3. The user authenticates at their identity provider and is redirected back to your callback.
+4. The plugin handles the callback automatically on install (as with a normal login). The ID token is verified and cached; read the claims with `idTokenClaims` / `user`.
+
+> [!IMPORTANT]
+> `isFederatedDomain` is a routing hint, not a security control. It returns `false` on any failure (a 429, a network error, or a genuinely unmanaged domain all look the same), so a discovery failure routes the user to your fallback login rather than granting access. It never, on its own, signs anyone in: the callback must still complete, and you must still validate the resulting claims (see [Validate the organization](#validate-the-organization)).
+
+### Configure the SDK
+
+Register the plugin as usual. Do not set `organization`: Home Realm Discovery resolves it from the `login_hint`.
+
+```js
+app.use(
+  createAuth0({
+    domain: '<AUTH0_DOMAIN>',
+    clientId: '<AUTH0_CLIENT_ID>',
+    authorizationParams: {
+      redirect_uri: '<MY_CALLBACK_URL>',
+      scope: 'openid profile email' // no offline_access -- EC issues no refresh token
+    }
+  })
+);
+```
+
+### Login
+
+`isFederatedDomain` is a standalone export (it runs before any client session exists), so import it directly from the package. Check the email domain, then start the redirect with the email as `login_hint`:
+
+```js
+<script>
+  import { useAuth0, isFederatedDomain } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { loginWithRedirect } = useAuth0();
+
+      return {
+        login: async email => {
+          const emailDomain = email.split('@')[1];
+
+          // 1. Discover whether the domain is managed for enterprise SSO
+          const federated = await isFederatedDomain('<AUTH0_DOMAIN>', emailDomain);
+
+          if (!federated) {
+            // Domain is not managed by Auth0; fall back to your own login
+            showPasswordForm(email);
+            return;
+          }
+
+          // 2. Redirect to Auth0 with the email as login_hint. Home Realm
+          //    Discovery resolves the connection and organization from the
+          //    domain -- do not pass organization yourself, or you break
+          //    multi-customer setups.
+          await loginWithRedirect({
+            authorizationParams: { login_hint: email }
+          });
+        }
+      };
+    }
+  };
+</script>
+```
+
+### Validate the organization
+
+> [!WARNING]
+> Validate `org_id` after every login. WebFinger discovery and `login_hint` are routing mechanisms, not proof that the user belongs to a customer you serve: on their own they do not authorize anyone. Read `org_id` from the ID token claims and check it against your own list of known organizations before treating the user as signed in for that customer. Without this check, a user authenticating through any managed connection could obtain a session in a context you did not intend.
+
+```js
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+  import { watch } from 'vue';
+
+  export default {
+    setup() {
+      const { idTokenClaims, logout } = useAuth0();
+
+      // `allowedOrgs` is a placeholder for illustration -- replace it with your
+      // own list of org_id values that this app is allowed to serve.
+      const allowedOrgs = ['org_...'];
+
+      watch(idTokenClaims, claims => {
+        if (claims && !allowedOrgs.includes(claims.org_id)) {
+          logout({ logoutParams: { federated: true } });
+        }
+      });
+    }
+  };
+</script>
+```
+
+This runs in the browser, so treat it as a UX guard, not real security. Always check `org_id` server-side too. Keep the check even if you serve one org today, or you silently let in other tenants the day you add a second customer.
+
+### Logout
+
+EC logout must use `federated: true` to terminate the enterprise IdP session (SAML SLO). Without it the IdP session stays alive and the next login silently reuses the previous user:
+
+```js
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { logout } = useAuth0();
+
+      return {
+        logout: () =>
+          logout({
+            logoutParams: {
+              federated: true,
+              returnTo: window.location.origin
+            }
+          })
+      };
+    }
+  };
+</script>
+```
+
 ## Device-bound tokens with DPoP
 
 **Demonstrating Proof-of-Possession** —or simply **DPoP**— is a recent OAuth 2.0 extension defined in [RFC9449](https://datatracker.ietf.org/doc/html/rfc9449).

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Explore public API's available in auth0-vue.
 - [createAuth0](https://auth0.github.io/auth0-vue/functions/createAuth0.html)
 - [createAuthGuard](https://auth0.github.io/auth0-vue/functions/createAuthGuard.html)
 - [useAuth0](https://auth0.github.io/auth0-vue/functions/useAuth0.html)
+- [isFederatedDomain](https://auth0.github.io/auth0-vue/functions/isFederatedDomain.html)
 - [Auth0PluginOptions](https://auth0.github.io/auth0-vue/interfaces/Auth0PluginOptions.html)
 - [Auth0VueClientOptions](https://auth0.github.io/auth0-vue/interfaces/Auth0VueClientOptions.html)
 - [Auth0VueClient](https://auth0.github.io/auth0-vue/interfaces/Auth0VueClient.html)

--- a/src/global.ts
+++ b/src/global.ts
@@ -21,7 +21,8 @@ export {
   MyAccountApiError,
   MissingScopesError,
   InvalidConfigurationError,
-  RefreshTokenMode
+  RefreshTokenMode,
+  isFederatedDomain
 } from '@auth0/auth0-spa-js';
 
 export type {
@@ -70,5 +71,6 @@ export type {
   UpdateAuthenticationMethodRequest,
   EnrollmentChallengeOptions,
   EnrollmentChallengeResponse,
-  EnrollmentVerifyOptions
+  EnrollmentVerifyOptions,
+  IsFederatedDomainOptions
 } from '@auth0/auth0-spa-js';


### PR DESCRIPTION
## Summary

Adds **Enterprise Connect** support to `auth0-vue` by re-exporting `isFederatedDomain` from `@auth0/auth0-spa-js` for enterprise domain discovery. The Enterprise Connect login, callback, and logout flows reuse existing SDK methods (`loginWithRedirect`, `handleRedirectCallback`, `logout`) unchanged. 

Enterprise Connect lets a B2B SaaS layer enterprise SSO (SAML, OIDC federation) on top of its own auth server: Auth0 authenticates the enterprise user against their IdP and returns an enriched ID token, which the plugin caches like any other login.

Because `isFederatedDomain` is a standalone function (not a client method), this is a thin pass-through: one re-export in `src/global.ts`, no new composable or plugin changes needed.

## Changes

- Re-export `isFederatedDomain` and `IsFederatedDomainOptions` from `@auth0/auth0-spa-js` through the public barrel (`src/global.ts`), matching the spa-js signature (caller passes `auth0Domain` and `emailDomain`).
- Add an Enterprise Connect section to `EXAMPLES.md` covering SDK config, domain discovery, `org_id` validation, and federated logout in Vue idioms.
- Add `isFederatedDomain` to the API reference in `README.md`.

## Example

```js
import { useAuth0, isFederatedDomain } from '@auth0/auth0-vue';

const { loginWithRedirect } = useAuth0();
const emailDomain = email.split('@')[1];

// Routing hint only: returns false on any failure, never authorises.
if (await isFederatedDomain('<AUTH0_DOMAIN>', emailDomain)) {
  // Home Realm Discovery resolves the connection and organization from the
  // domain -- do not pass organization yourself.
  await loginWithRedirect({ authorizationParams: { login_hint: email } });
}

// Federated logout terminates the enterprise IdP session (SAML SLO).
await logout({ logoutParams: { federated: true, returnTo: window.location.origin } });
```

> [!IMPORTANT]
> Enterprise Connect is an Early Access feature. `isFederatedDomain` is a routing hint, not a security control: always validate `org_id` from the ID token claims after the callback, and enforce it server-side on every request that trusts the token.

## Testing

- `npm test -- --maxWorkers=2`: 115 tests pass, 100% coverage maintained.
- `npm run build`: `isFederatedDomain` and `IsFederatedDomainOptions` bundle cleanly and appear in `dist/typings/global.d.ts`.
- `npm run lint` (scoped to `./src`): no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for checking whether a domain uses enterprise federation.
  * Exposed the federation-domain check and its configuration type through the package API.
  * Added guidance for configuring Enterprise Connect, handling organization claims, federated logout, and token renewal limitations.

* **Tests**
  * Added coverage for federated, unmanaged, and discovery-failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->